### PR TITLE
Implement prune, map, and fold for trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "tree_iterators_rs"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree_iterators_rs"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 description = "tree_iterators_rs is a library built to provide you with the iterators to easily work with tree data structures in Rust."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ into other iterators by chaining one of the following methods:
 
 ## Change Log
 
+- 3.1.0
+  - Adds the [prune](crate::prelude::OwnedTreeNode::prune), [map](crate::prelude::OwnedTreeNode::map), and [fold](crate::prelude::OwnedTreeNode::fold) methods to all Tree traits.
+  > **_NOTE_**: These are named `_mut` or `_ref` for the borrowed traits
+
 - 3.0.0
   - Renames TreeNode and BinaryTreeNode to Tree and BinaryTree respectively
   - Adds the attach_context() APIs. This new API allows for more context-aware

--- a/src/bfs_iterators/borrow.rs
+++ b/src/bfs_iterators/borrow.rs
@@ -1,5 +1,5 @@
 use alloc::{collections::VecDeque, vec::Vec};
-use core::{array::IntoIter, mem::MaybeUninit};
+use core::array::IntoIter;
 use streaming_iterator::StreamingIterator;
 
 use crate::{
@@ -94,7 +94,7 @@ where
         let iterator_queue = VecDeque::new();
         let mut current_context = TreeContext::new();
         current_context.ancestors.push(value);
-        current_context.children = MaybeUninit::new(children);
+        current_context.children = Some(children);
 
         BorrowedBFSIteratorWithContext {
             is_root: true,
@@ -304,7 +304,7 @@ where
         let iterator_queue = VecDeque::new();
         let mut current_context = TreeContext::new();
         current_context.ancestors.push(value);
-        current_context.children = MaybeUninit::new(children);
+        current_context.children = Some(children);
 
         Self {
             is_root: true,

--- a/src/bfs_iterators/mod.rs
+++ b/src/bfs_iterators/mod.rs
@@ -37,10 +37,8 @@ macro_rules! bfs_context_streaming_iterator_impl {
                 return;
             }
 
-            let mut children = core::mem::MaybeUninit::uninit();
-            core::mem::swap(&mut children, &mut self.current_context.children);
-            self.iterator_queue
-                .push_back(unsafe { children.assume_init() }.into_iter());
+            let children = self.current_context.children.take();
+            self.iterator_queue.push_back(children.unwrap().into_iter());
 
             loop {
                 if self.current_context.ancestors.len() == self.traversal_stack.len() + 2 {
@@ -55,7 +53,7 @@ macro_rules! bfs_context_streaming_iterator_impl {
 
                     let (value, children) = next.$get_value_and_children();
                     self.current_context.ancestors.push(value);
-                    self.current_context.children = core::mem::MaybeUninit::new(children);
+                    self.current_context.children = Some(children);
                     break;
                 }
 
@@ -207,10 +205,8 @@ macro_rules! bfs_context_binary_streaming_iterator_impl {
                 return;
             }
 
-            let mut children = core::mem::MaybeUninit::uninit();
-            core::mem::swap(&mut children, &mut self.current_context.children);
-            self.iterator_queue
-                .push_back(unsafe { children.assume_init() }.into_iter());
+            let children = self.current_context.children.take();
+            self.iterator_queue.push_back(children.unwrap().into_iter());
 
             'outer: loop {
                 if self.current_context.ancestors.len() == self.traversal_stack.len() + 2 {
@@ -226,7 +222,7 @@ macro_rules! bfs_context_binary_streaming_iterator_impl {
 
                         let (value, children) = next.$get_value_and_children_binary();
                         self.current_context.ancestors.push(value);
-                        self.current_context.children = core::mem::MaybeUninit::new(children);
+                        self.current_context.children = Some(children);
                         break 'outer;
                     } else {
                         self.path_counter += 1;

--- a/src/bfs_iterators/mut_borrow.rs
+++ b/src/bfs_iterators/mut_borrow.rs
@@ -1,4 +1,4 @@
-use core::{array::IntoIter, mem::MaybeUninit};
+use core::array::IntoIter;
 
 use alloc::{collections::VecDeque, vec::Vec};
 use streaming_iterator::{StreamingIterator, StreamingIteratorMut};
@@ -95,7 +95,7 @@ where
         let iterator_queue = VecDeque::new();
         let mut current_context = TreeContext::new();
         current_context.ancestors.push(value);
-        current_context.children = MaybeUninit::new(children);
+        current_context.children = Some(children);
 
         MutBorrowedBFSIteratorWithContext {
             is_root: true,
@@ -326,7 +326,7 @@ where
         let iterator_queue = VecDeque::new();
         let mut current_context = TreeContext::new();
         current_context.ancestors.push(value);
-        current_context.children = MaybeUninit::new(children);
+        current_context.children = Some(children);
 
         Self {
             is_root: true,

--- a/src/bfs_iterators/owned.rs
+++ b/src/bfs_iterators/owned.rs
@@ -1,4 +1,4 @@
-use core::{array::IntoIter, mem::MaybeUninit};
+use core::array::IntoIter;
 
 use alloc::{collections::VecDeque, vec::Vec};
 use streaming_iterator::{StreamingIterator, StreamingIteratorMut};
@@ -97,7 +97,7 @@ where
         let iterator_queue = VecDeque::new();
         let mut current_context = TreeContext::new();
         current_context.ancestors.push(value);
-        current_context.children = MaybeUninit::new(children);
+        current_context.children = Some(children);
 
         OwnedBFSIteratorWithContext {
             is_root: true,
@@ -328,7 +328,7 @@ where
         let iterator_queue = VecDeque::new();
         let mut current_context = TreeContext::new();
         current_context.ancestors.push(value);
-        current_context.children = MaybeUninit::new(children);
+        current_context.children = Some(children);
 
         Self {
             is_root: true,

--- a/src/dfs_inorder_iterators/borrow.rs
+++ b/src/dfs_inorder_iterators/borrow.rs
@@ -1,4 +1,4 @@
-use core::{mem::MaybeUninit, option::IntoIter};
+use core::option::IntoIter;
 
 use alloc::vec::Vec;
 use streaming_iterator::StreamingIterator;
@@ -189,7 +189,7 @@ where
                     TraversalStatus::WentLeft => {
                         *last_status = TraversalStatus::ReturnedSelf;
                         self.current_context.children =
-                            MaybeUninit::new(self.into_iterator_stack.pop().unwrap());
+                            Some(self.into_iterator_stack.pop().unwrap());
                         return;
                     }
                     TraversalStatus::ReturnedSelf => *last_status = TraversalStatus::WentRight,
@@ -228,7 +228,7 @@ where
         let status_stack_len = self.status_stack.len();
         self.status_stack[status_stack_len - 1] = TraversalStatus::ReturnedSelf;
 
-        self.current_context.children = MaybeUninit::new(
+        self.current_context.children = Some(
             self.into_iterator_stack
                 .pop()
                 .expect("There to be a children IntoIterator"),

--- a/src/dfs_inorder_iterators/mut_borrow.rs
+++ b/src/dfs_inorder_iterators/mut_borrow.rs
@@ -1,4 +1,4 @@
-use core::{mem::MaybeUninit, option::IntoIter};
+use core::option::IntoIter;
 
 use alloc::vec::Vec;
 use streaming_iterator::{StreamingIterator, StreamingIteratorMut};
@@ -201,7 +201,7 @@ where
                     TraversalStatus::WentLeft => {
                         *last_status = TraversalStatus::ReturnedSelf;
                         self.current_context.children =
-                            MaybeUninit::new(self.into_iterator_stack.pop().unwrap());
+                            Some(self.into_iterator_stack.pop().unwrap());
                         return;
                     }
                     TraversalStatus::ReturnedSelf => {
@@ -242,7 +242,7 @@ where
         let status_stack_len = self.status_stack.len();
         self.status_stack[status_stack_len - 1] = TraversalStatus::ReturnedSelf;
 
-        self.current_context.children = MaybeUninit::new(
+        self.current_context.children = Some(
             self.into_iterator_stack
                 .pop()
                 .expect("There to be a children IntoIterator"),

--- a/src/dfs_postorder_iterators/borrow.rs
+++ b/src/dfs_postorder_iterators/borrow.rs
@@ -1,4 +1,4 @@
-use core::{array::IntoIter, mem::MaybeUninit};
+use core::array::IntoIter;
 
 use crate::{
     leaves_iterators::{
@@ -150,7 +150,7 @@ where
                 }
             }
 
-            self.current_context.children = MaybeUninit::new(
+            self.current_context.children = Some(
                 self.into_iterator_stack
                     .pop()
                     .expect("There to be a childe IntoIterator"),
@@ -393,7 +393,7 @@ where
                 }
             }
 
-            self.current_context.children = MaybeUninit::new(
+            self.current_context.children = Some(
                 self.into_iterator_stack
                     .pop()
                     .expect("There to be a children IntoIterator"),

--- a/src/dfs_postorder_iterators/mut_borrow.rs
+++ b/src/dfs_postorder_iterators/mut_borrow.rs
@@ -1,4 +1,4 @@
-use core::{array::IntoIter, mem::MaybeUninit};
+use core::array::IntoIter;
 
 use crate::{
     leaves_iterators::{
@@ -154,7 +154,7 @@ where
                 }
             }
 
-            self.current_context.children = MaybeUninit::new(
+            self.current_context.children = Some(
                 self.into_iterator_stack
                     .pop()
                     .expect("There to be a children IntoIterator"),
@@ -423,7 +423,7 @@ where
                 }
             }
 
-            self.current_context.children = MaybeUninit::new(
+            self.current_context.children = Some(
                 self.into_iterator_stack
                     .pop()
                     .expect("There to be a children IntoIterator"),

--- a/src/dfs_preorder_iterators/owned.rs
+++ b/src/dfs_preorder_iterators/owned.rs
@@ -11,11 +11,15 @@ use crate::{
         },
         depth_first::owned::{OwnedBinaryLeavesIterator, OwnedLeavesIterator},
     },
-    prelude::{BinaryChildren, OwnedBinaryTreeNode, OwnedTreeNode, TreeContext},
+    prelude::{
+        BinaryChildren, BinaryTreeIterator, OwnedBinaryTreeNode, OwnedTreeNode, TreeContext,
+    },
+    tree_iterators::{TreeIterator, TreeIteratorBase},
 };
 
 use super::{
-    dfs_preorder_next, get_mut_ancestors, get_mut_context,
+    dfs_preorder_binary_next_with_path_tracking, dfs_preorder_next,
+    dfs_preorder_next_with_path_tracking, get_mut_ancestors, get_mut_context,
     preorder_ancestors_streaming_iterator_impl, preorder_binary_context_streaming_iterator_impl,
     preorder_context_streaming_iterator_impl,
 };
@@ -76,6 +80,62 @@ where
 {
     type Item = Node::OwnedValue;
     dfs_preorder_next!(get_value_and_children);
+}
+
+pub(crate) struct OwnedDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedTreeNode,
+{
+    root: Option<Node>,
+    path: Vec<usize>,
+    on_deck_into_iterator: Option<Node::OwnedChildren>,
+    traversal_stack: Vec<<Node::OwnedChildren as IntoIterator>::IntoIter>,
+}
+
+impl<Node> OwnedDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedTreeNode,
+{
+    pub(crate) fn new(root: Node) -> Self {
+        Self {
+            root: Some(root),
+            path: Vec::new(),
+            on_deck_into_iterator: None,
+            traversal_stack: Vec::new(),
+        }
+    }
+}
+
+impl<Node> Iterator for OwnedDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedTreeNode,
+{
+    type Item = Node::OwnedValue;
+    dfs_preorder_next_with_path_tracking!(get_value_and_children);
+}
+
+impl<Node> crate::Sealed for OwnedDFSPreorderIteratorWithPathTracking<Node> where Node: OwnedTreeNode
+{}
+
+impl<Node> TreeIteratorBase<Node::OwnedValue, Node::OwnedChildren>
+    for OwnedDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedTreeNode,
+{
+    fn current_path(&self) -> &[usize] {
+        &self.path
+    }
+
+    fn prune_current_subtree(&mut self) {
+        self.on_deck_into_iterator.take();
+    }
+}
+
+impl<Node> TreeIterator<Node::OwnedValue, Node::OwnedChildren>
+    for OwnedDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedTreeNode,
+{
 }
 
 pub struct OwnedDFSPreorderIteratorWithContext<Node>
@@ -172,7 +232,7 @@ where
     Node: OwnedBinaryTreeNode,
 {
     root: Option<Node>,
-    traversal_stack: Vec<BinaryChildren<Node>>,
+    pub(crate) traversal_stack: Vec<BinaryChildren<Node>>,
 }
 
 impl<Node> OwnedBinaryDFSPreorderIterator<Node>
@@ -223,6 +283,64 @@ where
 {
     type Item = Node::OwnedValue;
     dfs_preorder_next!(get_value_and_children);
+}
+
+pub(crate) struct OwnedBinaryDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedBinaryTreeNode,
+{
+    root: Option<Node>,
+    traversal_stack: Vec<IntoIter<Option<Node>, 2>>,
+    path: Vec<usize>,
+    on_deck_into_iterator: Option<[Option<Node>; 2]>,
+}
+
+impl<Node> OwnedBinaryDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedBinaryTreeNode,
+{
+    pub(crate) fn new(root: Node) -> Self {
+        Self {
+            root: Some(root),
+            traversal_stack: Vec::new(),
+            path: Vec::new(),
+            on_deck_into_iterator: None,
+        }
+    }
+}
+
+impl<Node> Iterator for OwnedBinaryDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedBinaryTreeNode,
+{
+    type Item = Node::OwnedValue;
+    dfs_preorder_binary_next_with_path_tracking!(get_value_and_children_binary);
+}
+
+impl<'a, Node> crate::Sealed for OwnedBinaryDFSPreorderIteratorWithPathTracking<Node> where
+    Node: OwnedBinaryTreeNode
+{
+}
+
+impl<'a, Node> TreeIteratorBase<Node::OwnedValue, [Option<Node>; 2]>
+    for OwnedBinaryDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedBinaryTreeNode,
+{
+    fn current_path(&self) -> &[usize] {
+        &self.path
+    }
+
+    fn prune_current_subtree(&mut self) {
+        self.on_deck_into_iterator.take();
+    }
+}
+
+impl<'a, Node> BinaryTreeIterator<Node::OwnedValue, [Option<Node>; 2]>
+    for OwnedBinaryDFSPreorderIteratorWithPathTracking<Node>
+where
+    Node: OwnedBinaryTreeNode,
+{
 }
 
 pub struct OwnedBinaryDFSPreorderIteratorWithAncestors<Node>

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -1,5 +1,5 @@
-use crate::prelude::*;
-use alloc::{boxed::Box, vec};
+use crate::prelude::{Tree, BinaryTree};
+use alloc::boxed::Box;
 
 pub fn create_example_binary_tree() -> BinaryTree<usize> {
     BinaryTree {
@@ -50,6 +50,7 @@ pub fn create_example_binary_tree() -> BinaryTree<usize> {
 }
 
 pub fn create_example_tree() -> Tree<usize> {
+    use alloc::vec;
     use alloc::vec::Vec;
 
     Tree {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,6 @@ pub mod examples;
 pub mod leaves_iterators;
 pub mod prelude;
 mod tree_context;
+pub(crate) mod tree_iterators;
+
+pub(crate) trait Sealed {}

--- a/src/tree_context.rs
+++ b/src/tree_context.rs
@@ -1,5 +1,3 @@
-use core::mem::MaybeUninit;
-
 use alloc::vec::Vec;
 
 #[derive(Debug)]
@@ -11,7 +9,7 @@ pub struct TreeContext<Value, Children> {
     pub(crate) ancestors: Vec<Value>,
 
     #[doc = include_str!("../doc_files/tree_context_children.md")]
-    pub(crate) children: MaybeUninit<Children>,
+    pub(crate) children: Option<Children>,
 }
 
 impl<Value, Children> TreeContext<Value, Children> {
@@ -19,8 +17,31 @@ impl<Value, Children> TreeContext<Value, Children> {
         Self {
             path: Vec::new(),
             ancestors: Vec::new(),
-            children: MaybeUninit::uninit(),
+            children: None,
         }
+    }
+
+    /// Gets the depth of the current node in the tree. This is zero-based,
+    /// so the root node is at depth zero.
+    ///
+    /// Ex. given a tree like the following, the depths would be as labeled.
+    /// ```text
+    ///        0       <- depth: 0
+    ///       / \
+    ///      1   2     <- depth: 1
+    ///     / \ / \
+    ///    3  4 5  6   <- depth: 2
+    ///           /
+    ///          7     <- depth: 3
+    ///           \
+    ///            8   <- depth: 4
+    ///           /
+    ///          9     <- depth: 5
+    ///           \
+    ///           10   <- depth: 6
+    /// ```
+    pub fn depth(&self) -> usize {
+        self.ancestors().len() - 1
     }
 
     #[doc = include_str!("../doc_files/path.md")]
@@ -41,12 +62,12 @@ impl<Value, Children> TreeContext<Value, Children> {
     #[doc = include_str!("../doc_files/tree_context_children.md")]
     pub fn children(&self) -> &Children {
         // children should always be populated unless the iterator is in the middle of its .next() method.
-        unsafe { self.children.assume_init_ref() }
+        self.children.as_ref().unwrap()
     }
 
     #[doc = include_str!("../doc_files/tree_context_children.md")]
     pub fn children_mut(&mut self) -> &mut Children {
         // children should always be populated unless the iterator is in the middle of its .next() method.
-        unsafe { self.children.assume_init_mut() }
+        self.children.as_mut().unwrap()
     }
 }

--- a/src/tree_iterators/map.rs
+++ b/src/tree_iterators/map.rs
@@ -1,0 +1,80 @@
+use core::marker::PhantomData;
+
+use super::{BinaryTreeIterator, TreeIterator, TreeIteratorBase};
+
+pub struct Map<Value, Children, InnerIter, F, Output>
+where
+    InnerIter: TreeIteratorBase<Value, Children>,
+    F: FnMut(Value) -> Output,
+{
+    phantom1: PhantomData<Value>,
+    phantom2: PhantomData<Children>,
+    inner: InnerIter,
+    f: F,
+}
+
+impl<Value, Children, InnerIter, F, Output> Map<Value, Children, InnerIter, F, Output>
+where
+    InnerIter: TreeIteratorBase<Value, Children>,
+    F: FnMut(Value) -> Output,
+{
+    pub(crate) fn new(iter: InnerIter, f: F) -> Self {
+        Self {
+            phantom1: Default::default(),
+            phantom2: Default::default(),
+            inner: iter,
+            f,
+        }
+    }
+}
+
+impl<Value, Children, InnerIter, F, Output> crate::Sealed
+    for Map<Value, Children, InnerIter, F, Output>
+where
+    InnerIter: TreeIteratorBase<Value, Children>,
+    F: FnMut(Value) -> Output,
+{
+}
+
+impl<Value, Children, InnerIter, F, Output> Iterator for Map<Value, Children, InnerIter, F, Output>
+where
+    InnerIter: TreeIteratorBase<Value, Children>,
+    F: FnMut(Value) -> Output,
+{
+    type Item = Output;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|value| (&mut self.f)(value))
+    }
+}
+
+impl<Value, Children, InnerIter, F, Output> TreeIteratorBase<Output, ()>
+    for Map<Value, Children, InnerIter, F, Output>
+where
+    InnerIter: TreeIteratorBase<Value, Children>,
+    F: FnMut(Value) -> Output,
+{
+    fn current_path(&self) -> &[usize] {
+        self.inner.current_path()
+    }
+
+    fn prune_current_subtree(&mut self) {
+        self.inner.prune_current_subtree();
+    }
+}
+
+impl<Value, Children, InnerIter, F, Output> TreeIterator<Output, ()>
+    for Map<Value, Children, InnerIter, F, Output>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(Value) -> Output,
+{
+}
+
+impl<Value, Children, InnerIter, F, Output> BinaryTreeIterator<Output, ()>
+    for Map<Value, Children, InnerIter, F, Output>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(Value) -> Output,
+{
+}

--- a/src/tree_iterators/mod.rs
+++ b/src/tree_iterators/mod.rs
@@ -1,0 +1,650 @@
+use alloc::{boxed::Box, vec::Vec};
+
+use crate::prelude::{BinaryTree, Tree};
+
+mod map;
+pub use map::Map;
+
+mod prune;
+mod prune_depth;
+mod prune_path;
+pub use prune::{BinaryPrune, Prune};
+pub use prune_depth::PruneDepth;
+pub use prune_path::{BinaryPrunePath, PrunePath};
+
+#[allow(private_bounds)]
+pub trait TreeIteratorBase<Value, Children>: crate::Sealed + Iterator<Item = Value>
+where
+    Self: Sized,
+{
+    #[doc = include_str!("../../doc_files/path.md")]
+    fn current_path(&self) -> &[usize];
+
+    /// Gets the depth of the current node in the tree. This is zero-based,
+    /// so the root node is at depth zero.
+    ///
+    /// Ex. given a tree like the following, the depths would be as labeled.
+    /// ```text
+    ///        0       <- depth: 0
+    ///       / \
+    ///      1   2     <- depth: 1
+    ///     / \ / \
+    ///    3  4 5  6   <- depth: 2
+    ///           /
+    ///          7     <- depth: 3
+    ///           \
+    ///            8   <- depth: 4
+    ///           /
+    ///          9     <- depth: 5
+    ///           \
+    ///           10   <- depth: 6
+    /// ```
+    fn current_depth(&self) -> usize {
+        self.current_path().len()
+    }
+
+    /// For use in tree_iterators_rs internals. Consumers should prefer using one of the following
+    /// public APIs to accomplish their task:
+    /// 1. [`TreeIterator::prune`] or [`BinaryTreeIterator::prune`]
+    /// 2. [`prune_depth`](TreeIteratorBase::prune_depth)
+    fn prune_current_subtree(&mut self);
+
+    /// Takes a depth and prunes the tree such that all nodes at a higher depth
+    /// are pruned from the tree.
+    ///
+    /// Depth is zero-based, so the root node is at depth zero.
+    ///
+    /// Ex. given a tree like the following, the depths would be as labeled.
+    /// ```text
+    ///        0       <- depth: 0
+    ///       / \
+    ///      1   2     <- depth: 1
+    ///     / \ / \
+    ///    3  4 5  6   <- depth: 2
+    ///           /
+    ///          7     <- depth: 3
+    ///           \
+    ///            8   <- depth: 4
+    ///           /
+    ///          9     <- depth: 5
+    ///           \
+    ///           10   <- depth: 6
+    /// ```
+    ///
+    /// Calling prune_depth with a depth of 2 would yield the following tree:
+    /// ```text
+    ///        0       <- depth: 0
+    ///       / \
+    ///      1   2     <- depth: 1
+    ///     / \ / \
+    ///    3  4 5  6   <- depth: 2
+    /// ```
+    ///
+    /// ### Example Usage
+    /// ```rust
+    /// use tree_iterators_rs::prelude::{Tree, OwnedTreeNode, TreeIterator, TreeIteratorBase};
+    ///
+    /// let tree = Tree {
+    ///     value: 0,
+    ///     children: vec![Tree {
+    ///         value: 1,
+    ///         children: vec![],
+    ///     }],
+    /// };
+    ///
+    /// let result =
+    ///     tree.into_pipeline()
+    ///         .prune_depth(0)
+    ///         .collect_tree()
+    ///         .expect("the root of the tree to remain un-pruned");
+    ///
+    /// assert_eq!(
+    ///     Tree {
+    ///         value: 0,
+    ///         children: vec![],
+    ///     },
+    ///     result);
+    /// ```
+    fn prune_depth(self, depth_limit: usize) -> PruneDepth<Value, Children, Self> {
+        PruneDepth {
+            inner: self,
+            depth: depth_limit,
+            value: Default::default(),
+            children: Default::default(),
+        }
+    }
+
+    /// map_tree is the tree-based analog of [`Iterator::map`]. It is named
+    /// as such to avoid name conflicts with [`Iterator::map`]. Takes a tree
+    /// of values and maps each value to a new value.
+    ///
+    /// Takes a closure and creates a TreeIterator or BinaryTreeIterator which
+    /// calls that closure on each element.
+    ///
+    /// map_tree() transforms one TreeIterator into another, by means of its argument:
+    /// something that implements FnMut. It produces a new iterator which calls
+    /// this closure on each element of the original iterator.
+    ///
+    /// If you are good at thinking in types, you can think of map_tree() like this: If
+    /// you have a TreeIterator that gives you elements of some type A, and you want a
+    /// TreeIterator of some other type B, you can use map_tree(), passing a closure that
+    /// takes an A and returns a B.
+    ///
+    /// ### Basic Usage
+    /// ```rust
+    /// use tree_iterators_rs::prelude::{Tree, OwnedTreeNode, TreeIterator, TreeIteratorBase};
+    ///
+    /// let tree = Tree {
+    ///     value: 0,
+    ///     children: vec![Tree {
+    ///         value: 1,
+    ///         children: vec![],
+    ///     }],
+    /// };
+    ///
+    /// let result =
+    ///     tree.into_pipeline()
+    ///         .map_tree(|value| value + 1)
+    ///         .collect_tree()
+    ///         .expect("the root of the tree to remain un-pruned");
+    ///
+    /// assert_eq!(
+    ///     Tree {
+    ///         value: 1,
+    ///         children: vec![Tree {
+    ///             value: 2,
+    ///             children: vec![],
+    ///         }],
+    ///     },
+    ///     result);
+    /// ```
+    fn map_tree<F, Output>(self, f: F) -> Map<Value, Children, Self, F, Output>
+    where
+        F: FnMut(Value) -> Output,
+    {
+        Map::new(self, f)
+    }
+}
+
+pub trait TreeIterator<Value, Children>: TreeIteratorBase<Value, Children>
+where
+    Self: Sized,
+{
+    /// Prune is a tree-based analog to [`filter`](core::iter::Iterator::filter).
+    /// Uses the given closure to determine if each subtree in this tree should be pruned.
+    ///
+    /// Given an element the closure must return true or false. Any nodes in the tree for
+    /// which this evaluates to true will be pruned out of the resulting tree. If the root node
+    /// is pruned, any subsequent calls to [`collect_tree`](TreeIterator::collect_tree)
+    /// will yield [`None`].
+    ///
+    /// The closure is called on the nodes in a depth first preorder traversal order (see
+    /// [`dfs_preorder`](crate::prelude::OwnedTreeNode::dfs_preorder) for more details). If a
+    /// node is determined to be pruned, its entire subtree will be pruned without calling the
+    /// closure on its descendent nodes.
+    ///
+    /// ### Basic usage:
+    /// ```rust
+    /// use tree_iterators_rs::prelude::{Tree, TreeIterator, OwnedTreeNode, TreeIteratorBase};
+    ///
+    /// let tree = Tree {
+    ///     value: 0,
+    ///     children: vec![
+    ///         Tree {
+    ///             value: 1,
+    ///             children: vec![Tree {
+    ///                 value: 3,
+    ///                 children: vec![],
+    ///             }],
+    ///         },
+    ///         Tree {
+    ///             value: 2,
+    ///             children: vec![],
+    ///         },
+    ///     ],
+    /// };
+    ///
+    /// let result = tree.into_pipeline()
+    ///     .prune(|value| {
+    ///         println!("{value:?}");
+    ///         *value == 1
+    ///     })
+    ///     .collect_tree();
+    ///
+    /// assert_eq!(
+    ///     Some(Tree {
+    ///         value: 0,
+    ///         children: vec![Tree {
+    ///             value: 2,
+    ///             children: vec![],
+    ///         }],
+    ///     }),
+    ///     result);
+    /// ```
+    /// The output for this code would be the following. A couple notes about this output:
+    /// 1. the node with a value of '1' has been removed
+    /// 2. the closure is never called on the node with a value of '3' since it is already
+    ///    determined to be pruned once '1' has been evaluated.
+    ///
+    /// ```text
+    /// 0
+    /// 1
+    /// 2
+    /// ```
+    fn prune<F>(self, f: F) -> Prune<Value, Children, Self, F>
+    where
+        F: FnMut(&Value) -> bool,
+    {
+        Prune::new(self, f)
+    }
+
+    /// Identical to [`prune`](TreeIterator::prune) except that the closure is passed
+    /// an additional parameter: the path of the current node in the tree (see
+    /// [`current_path`](TreeIteratorBase::current_path) for more details).
+    fn prune_path<F>(self, f: F) -> PrunePath<Value, Children, Self, F>
+    where
+        F: FnMut(&[usize], &Value) -> bool,
+    {
+        PrunePath::new(self, f)
+    }
+
+    /// Collects the current TreeIterator back into a Tree.
+    ///
+    /// If the TreeIterator is empty (usually due to pruning the root node), yields
+    /// [`None`].
+    ///
+    /// ### Example Usage
+    /// ```rust
+    /// use tree_iterators_rs::prelude::{Tree, OwnedTreeNode, TreeIterator};
+    ///
+    /// let tree = Tree {
+    ///     value: 0,
+    ///     children: vec![],
+    /// };
+    ///
+    /// let result =
+    ///     tree.into_pipeline()
+    ///         .collect_tree()
+    ///         .expect("the root of the tree to remain un-pruned");
+    ///
+    /// assert_eq!(
+    ///     Tree {
+    ///         value: 0,
+    ///         children: vec![],
+    ///     },
+    ///     result);
+    /// ```
+    fn collect_tree(mut self) -> Option<Tree<Value>> {
+        let mut keeping_stack: Vec<Tree<Value>> = Vec::new();
+        while let Some(item) = self.next() {
+            while keeping_stack.len() > self.current_depth() {
+                let popped = keeping_stack
+                    .pop()
+                    .expect("the keeping stack to always have an item");
+
+                let last_keeping_children = keeping_stack
+                    .last_mut()
+                    .expect("there to always be an item in the keeping stack.");
+
+                last_keeping_children.children.push(popped);
+            }
+
+            keeping_stack.push(Tree {
+                value: item,
+                children: Vec::new(),
+            });
+        }
+
+        while keeping_stack.len() > 1 {
+            let popped = keeping_stack
+                .pop()
+                .expect("the keeping stack to always have an item");
+
+            let last_keeping_children = keeping_stack
+                .last_mut()
+                .expect("there to always be an item in the keeping stack.");
+
+            last_keeping_children.children.push(popped);
+        }
+
+        keeping_stack.pop()
+    }
+
+    /// A tree-based analog to [`fold`](Iterator::fold).
+    ///
+    /// Folds every node in the tree into an accumulated value by applying an operation,
+    /// returning the final result.
+    ///
+    /// fold() takes one arguments: a closure with two arguments: an ‘accumulator’ (the
+    /// result of accumulating all children of the current node), and the current node's
+    /// value. The closure returns the value that the accumulator should have for the
+    /// subtree's parent's iteration.
+    ///
+    /// After applying this closure to every element of the iterator, fold() returns the
+    /// accumulator.
+    ///
+    /// Folding is useful whenever you have a tree of something, and want to produce a
+    /// single value from it.
+    ///
+    /// ### Basic Usage
+    /// ```rust
+    /// use tree_iterators_rs::prelude::{Tree, OwnedTreeNode, TreeIterator};
+    ///
+    /// let tree = Tree {
+    ///     value: 0,
+    ///     children: vec![
+    ///         Tree {
+    ///             value: 1,
+    ///             children: vec![],
+    ///         },
+    ///         Tree {
+    ///             value: 2,
+    ///             children: vec![Tree {
+    ///                 value: 3,
+    ///                 children: vec![],
+    ///             }],
+    ///         },
+    ///     ],
+    /// };
+    ///
+    /// let num_nodes_in_tree =
+    ///     tree.into_pipeline()
+    ///         .fold_tree(|children, value| {
+    ///             let num_nodes_in_subtrees = children
+    ///                 .into_iter()
+    ///                 .sum::<usize>();
+    ///
+    ///             num_nodes_in_subtrees + 1
+    ///         })
+    ///         .expect("the root of the tree to remain un-pruned");
+    ///
+    /// assert_eq!(num_nodes_in_tree, 4);
+    /// ```
+    fn fold_tree<F, Output>(mut self, mut f: F) -> Option<Output>
+    where
+        F: FnMut(Vec<Output>, Value) -> Output,
+    {
+        let mut inversion_stack: Vec<Value> = Vec::new();
+        let mut folded_so_far: Vec<Vec<Output>> = Vec::new();
+        while let Some(item) = self.next() {
+            while folded_so_far.len() > self.current_depth() {
+                let items = folded_so_far.pop().unwrap();
+                let value_to_fold = inversion_stack.pop().unwrap();
+                let folded = f(items, value_to_fold);
+                folded_so_far.last_mut().unwrap().push(folded);
+            }
+
+            inversion_stack.push(item);
+            folded_so_far.push(Vec::new())
+        }
+
+        while folded_so_far.len() > 1 {
+            let items = folded_so_far.pop().unwrap();
+            let value_to_fold = inversion_stack.pop().unwrap();
+            let folded = f(items, value_to_fold);
+            folded_so_far.last_mut().unwrap().push(folded);
+        }
+
+        if let Some(root) = inversion_stack.pop() {
+            Some(f(folded_so_far.pop().unwrap_or_default(), root))
+        } else {
+            None
+        }
+    }
+}
+
+pub trait BinaryTreeIterator<Value, Children>: TreeIteratorBase<Value, Children>
+where
+    Self: Sized,
+{
+    /// Prune is a tree-based analog to [`filter`](core::iter::Iterator::filter).
+    /// Uses the given closure to determine if each subtree in this tree should be pruned.
+    ///
+    /// Given an element the closure must return true or false. Any nodes in the tree for
+    /// which this evaluates to true will be pruned out of the resulting tree. If the root node
+    /// is pruned, any subsequent calls to [`collect_tree`](BinaryTreeIterator::collect_tree)
+    /// will yield [`None`].
+    ///
+    /// The closure is called on the nodes in a depth first preorder traversal order (see
+    /// [`dfs_preorder`](crate::prelude::OwnedTreeNode::dfs_preorder) for more details). If a
+    /// node is determined to be pruned, its entire subtree will be pruned without calling the
+    /// closure on its descendent nodes.
+    ///
+    /// ### Basic usage:
+    /// ```rust
+    /// use tree_iterators_rs::prelude::{BinaryTree, BinaryTreeIterator, OwnedBinaryTreeNode, TreeIteratorBase};
+    ///
+    /// let tree = BinaryTree {
+    ///     value: 0,
+    ///     left: Some(Box::new(BinaryTree {
+    ///         value: 1,
+    ///         left: Some(Box::new(BinaryTree {
+    ///             value: 3,
+    ///             left: None,
+    ///             right: None,
+    ///         })),
+    ///         right: None,
+    ///     })),
+    ///     right: Some(Box::new(BinaryTree {
+    ///         value: 2,
+    ///         left: None,
+    ///         right: None,
+    ///     }))
+    /// };
+    ///
+    /// let result = tree.into_pipeline()
+    ///     .prune(|value| {
+    ///         println!("{value:?}");
+    ///         *value == 1
+    ///     })
+    ///     .collect_tree();
+    ///
+    /// assert_eq!(
+    ///     Some(BinaryTree {
+    ///         value: 0,
+    ///         left: None,
+    ///         right: Some(Box::new(BinaryTree {
+    ///             value: 2,
+    ///             left: None,
+    ///             right: None,
+    ///         })),
+    ///     }),
+    ///     result);
+    /// ```
+    /// The output for this code would be the following. A couple notes about this output:
+    /// 1. the node with a value of '1' has been removed
+    /// 2. the closure is never called on the node with a value of '3' since it is already
+    ///    determined to be pruned once '1' has been evaluated.
+    ///
+    /// ```text
+    /// 0
+    /// 1
+    /// 2
+    /// ```
+    fn prune<F>(self, f: F) -> BinaryPrune<Value, Children, Self, F>
+    where
+        F: FnMut(&Value) -> bool,
+    {
+        BinaryPrune::new(self, f)
+    }
+
+    /// Identical to [`prune`](TreeIterator::prune) except that the closure is passed
+    /// an additional parameter: the path of the current node in the tree (see
+    /// [`current_path`](TreeIteratorBase::current_path) for more details).
+    fn prune_path<F>(self, f: F) -> BinaryPrunePath<Value, Children, Self, F>
+    where
+        F: FnMut(&[usize], &Value) -> bool,
+    {
+        BinaryPrunePath::new(self, f)
+    }
+
+    /// Collects the current [`BinaryTreeIterator`] back into a BinaryTree.
+    ///
+    /// If the BinaryTreeIterator is empty (usually due to pruning the root node),
+    /// yields [`None`].
+    ///
+    /// ### Example Usage
+    /// ```rust
+    /// use tree_iterators_rs::prelude::{BinaryTree, OwnedBinaryTreeNode, BinaryTreeIterator};
+    ///
+    /// let tree = BinaryTree {
+    ///     value: 0,
+    ///     left: None,
+    ///     right: None,
+    /// };
+    ///
+    /// let result =
+    ///     tree.into_pipeline()
+    ///         .collect_tree()
+    ///         .expect("the root of the tree to remain un-pruned");
+    ///
+    /// assert_eq!(
+    ///     BinaryTree {
+    ///         value: 0,
+    ///         left: None,
+    ///         right: None,
+    ///     },
+    ///     result);
+    /// ```
+    fn collect_tree(mut self) -> Option<BinaryTree<Value>> {
+        let mut keeping_stack: Vec<(usize, BinaryTree<Value>)> = Vec::new();
+        while let Some(item) = self.next() {
+            while keeping_stack.len() > self.current_depth() {
+                let popped: (usize, BinaryTree<Value>) = keeping_stack
+                    .pop()
+                    .expect("the keeping stack to always have an item");
+
+                let last_keeping_children = keeping_stack
+                    .last_mut()
+                    .expect("there to always be an item in the keeping stack.");
+
+                match popped.0 {
+                    0 => last_keeping_children.1.left = Some(Box::new(popped.1)),
+                    1 => last_keeping_children.1.right = Some(Box::new(popped.1)),
+                    _ => unreachable!(
+                        "binary trees should only ever have paths that include 0's and 1's"
+                    ),
+                }
+            }
+
+            let index = self.current_path().last().map(|i| *i).unwrap_or_default();
+
+            keeping_stack.push((
+                index,
+                BinaryTree {
+                    value: item,
+                    left: None,
+                    right: None,
+                },
+            ));
+        }
+
+        while keeping_stack.len() > 1 {
+            let popped = keeping_stack
+                .pop()
+                .expect("the keeping stack to always have an item");
+
+            let last_keeping_children = keeping_stack
+                .last_mut()
+                .expect("there to always be an item in the keeping stack.");
+
+            match popped.0 {
+                0 => last_keeping_children.1.left = Some(Box::new(popped.1)),
+                1 => last_keeping_children.1.right = Some(Box::new(popped.1)),
+                _ => unreachable!(
+                    "binary trees should only ever have paths that include 0's and 1's"
+                ),
+            }
+        }
+
+        keeping_stack.pop().map(|tuple| tuple.1)
+    }
+
+    /// A tree-based analog to [`fold`](Iterator::fold).
+    ///
+    /// Folds every node in the tree into an accumulated value by applying an operation,
+    /// returning the final result.
+    ///
+    /// fold() takes one arguments: a closure with two arguments: an ‘accumulator’ (the
+    /// result of accumulating both children of the current node), and the current node's
+    /// value. The closure returns the value that the accumulator should have for the
+    /// subtree's parent's iteration.
+    ///
+    /// After applying this closure to every element of the iterator, fold() returns the
+    /// accumulator.
+    ///
+    /// Folding is useful whenever you have a tree of something, and want to produce a
+    /// single value from it.
+    ///
+    /// ### Basic Usage
+    /// ```rust
+    /// use tree_iterators_rs::prelude::{BinaryTree, OwnedBinaryTreeNode, BinaryTreeIterator};
+    ///
+    /// let tree = BinaryTree {
+    ///     value: 0,
+    ///     left: Some(Box::new(BinaryTree {
+    ///         value: 1,
+    ///         left: None,
+    ///         right: None,
+    ///     })),
+    ///     right: Some(Box::new(BinaryTree {
+    ///         value: 2,
+    ///         left: None,
+    ///         right: Some(Box::new(BinaryTree {
+    ///             value: 3,
+    ///             left: None,
+    ///             right: None,
+    ///         })),
+    ///     })),
+    /// };
+    ///
+    /// let num_nodes_in_tree =
+    ///     tree.into_pipeline()
+    ///         .fold_tree(|children, value| {
+    ///             let num_nodes_in_subtrees = children
+    ///                 .into_iter()
+    ///                 .flat_map(|opt| opt)
+    ///                 .sum::<usize>();
+    ///
+    ///             num_nodes_in_subtrees + 1
+    ///         })
+    ///         .expect("the root of the tree to remain un-pruned");
+    ///
+    /// assert_eq!(num_nodes_in_tree, 4);
+    /// ```
+    fn fold_tree<F, Output>(mut self, mut f: F) -> Option<Output>
+    where
+        F: FnMut([Option<Output>; 2], Value) -> Output,
+    {
+        let mut inversion_stack = Vec::new();
+        let mut folded_so_far = Vec::new();
+        let mut paths = Vec::new();
+        while let Some(item) = self.next() {
+            while folded_so_far.len() > self.current_depth() {
+                let items = folded_so_far.pop().unwrap();
+                let value_to_fold = inversion_stack.pop().unwrap();
+                let path_segment = paths.pop().unwrap();
+                let folded = f(items, value_to_fold);
+                folded_so_far.last_mut().unwrap()[path_segment] = Some(folded);
+            }
+
+            inversion_stack.push(item);
+            folded_so_far.push(Default::default());
+            paths.push(self.current_path().last().map(|i| *i).unwrap_or_default());
+        }
+
+        while folded_so_far.len() > 1 {
+            let items = folded_so_far.pop().unwrap();
+            let value_to_fold = inversion_stack.pop().unwrap();
+            let path_segment = paths.pop().unwrap();
+            let folded = f(items, value_to_fold);
+            folded_so_far.last_mut().unwrap()[path_segment] = Some(folded);
+        }
+
+        if let Some(root) = inversion_stack.pop() {
+            Some(f(folded_so_far.pop().unwrap_or_default(), root))
+        } else {
+            None
+        }
+    }
+}

--- a/src/tree_iterators/prune.rs
+++ b/src/tree_iterators/prune.rs
@@ -1,0 +1,206 @@
+use core::marker::PhantomData;
+
+use alloc::vec::Vec;
+
+use super::{BinaryTreeIterator, TreeIterator, TreeIteratorBase};
+
+pub struct Prune<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+    phantom1: PhantomData<Value>,
+    phantom2: PhantomData<Children>,
+    inner: InnerIter,
+    f: F,
+    pruned_at_each_depth: Vec<usize>,
+    current_path: Vec<usize>,
+}
+
+impl<Value, Children, InnerIter, F> Prune<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+    pub(crate) fn new(iter: InnerIter, f: F) -> Self {
+        Self {
+            phantom1: Default::default(),
+            phantom2: Default::default(),
+            inner: iter,
+            f,
+            pruned_at_each_depth: Vec::new(),
+            current_path: Vec::new(),
+        }
+    }
+}
+
+impl<Value, Children, InnerIter, F> Iterator for Prune<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(item) = self.inner.next() {
+            let inner_depth = self.inner.current_depth();
+
+            if self.pruned_at_each_depth.len() < inner_depth {
+                self.pruned_at_each_depth.push(0);
+                self.current_path.push(0);
+            }
+
+            if (&mut self.f)(&item) {
+                self.prune_current_subtree();
+                if inner_depth > 0 {
+                    let pruned_at_current_depth = &mut self.pruned_at_each_depth[inner_depth - 1];
+                    *pruned_at_current_depth += 1;
+                }
+                continue;
+            }
+
+            let mut matched_up_to_depth = 0;
+            let inner_path = self.inner.current_path();
+
+            loop {
+                if matched_up_to_depth >= inner_depth {
+                    self.current_path.truncate(matched_up_to_depth);
+                    break;
+                }
+
+                let current_path_at_depth = self.current_path[matched_up_to_depth];
+                let pruned_at_depth = self.pruned_at_each_depth[matched_up_to_depth];
+                let inner_path_at_depth = inner_path[matched_up_to_depth];
+                if (current_path_at_depth + pruned_at_depth) != inner_path_at_depth {
+                    self.pruned_at_each_depth.truncate(matched_up_to_depth + 1);
+                    self.current_path.truncate(matched_up_to_depth);
+                    break;
+                }
+
+                matched_up_to_depth += 1;
+            }
+
+            for depth in matched_up_to_depth..inner_depth {
+                let inner_at_depth = inner_path[depth];
+                if self.pruned_at_each_depth.len() == depth {
+                    self.pruned_at_each_depth.push(0);
+                }
+                let pruned_at_depth = self.pruned_at_each_depth[depth];
+                self.current_path.push(inner_at_depth - pruned_at_depth);
+            }
+
+            return Some(item);
+        }
+
+        self.current_path.clear();
+        self.current_path.shrink_to_fit();
+        None
+    }
+}
+
+impl<Value, Children, InnerIter, F> crate::Sealed for Prune<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+}
+
+impl<Value, Children, InnerIter, F> TreeIteratorBase<Value, Children>
+    for Prune<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+    fn current_path(&self) -> &[usize] {
+        &self.current_path
+    }
+
+    fn prune_current_subtree(&mut self) {
+        self.inner.prune_current_subtree();
+    }
+}
+
+impl<Value, Children, InnerIter, F> TreeIterator<Value, Children>
+    for Prune<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+}
+
+pub struct BinaryPrune<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIteratorBase<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+    phantom1: PhantomData<Value>,
+    phantom2: PhantomData<Children>,
+    inner: InnerIter,
+    f: F,
+}
+
+impl<Value, Children, InnerIter, F> BinaryPrune<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+    pub(crate) fn new(iter: InnerIter, f: F) -> Self {
+        Self {
+            phantom1: Default::default(),
+            phantom2: Default::default(),
+            inner: iter,
+            f,
+        }
+    }
+}
+
+impl<Value, Children, InnerIter, F> Iterator for BinaryPrune<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(item) = self.inner.next() {
+            if (&mut self.f)(&item) {
+                self.prune_current_subtree();
+                continue;
+            }
+
+            return Some(item);
+        }
+
+        None
+    }
+}
+
+impl<Value, Children, InnerIter, F> crate::Sealed for BinaryPrune<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+}
+
+impl<Value, Children, InnerIter, F> TreeIteratorBase<Value, Children>
+    for BinaryPrune<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+    fn current_path(&self) -> &[usize] {
+        self.inner.current_path()
+    }
+
+    fn prune_current_subtree(&mut self) {
+        self.inner.prune_current_subtree();
+    }
+}
+
+impl<Value, Children, InnerIter, F> BinaryTreeIterator<Value, Children>
+    for BinaryPrune<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&Value) -> bool,
+{
+}

--- a/src/tree_iterators/prune_depth.rs
+++ b/src/tree_iterators/prune_depth.rs
@@ -1,0 +1,66 @@
+use core::marker::PhantomData;
+
+use super::{BinaryTreeIterator, TreeIterator, TreeIteratorBase};
+
+pub struct PruneDepth<Value, Children, Inner>
+where
+    Inner: TreeIteratorBase<Value, Children>,
+{
+    pub(crate) value: PhantomData<Value>,
+    pub(crate) children: PhantomData<Children>,
+    pub(crate) inner: Inner,
+    pub(crate) depth: usize,
+}
+
+impl<Value, Children, Inner> crate::Sealed for PruneDepth<Value, Children, Inner> where
+    Inner: TreeIteratorBase<Value, Children>
+{
+}
+
+impl<Value, Children, Inner> Iterator for PruneDepth<Value, Children, Inner>
+where
+    Inner: TreeIteratorBase<Value, Children>,
+{
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Value> {
+        while let Some(value) = self.inner.next() {
+            if self.current_depth() == self.depth {
+                self.prune_current_subtree();
+            }
+
+            return Some(value);
+        }
+
+        None
+    }
+}
+
+impl<Value, Children, Inner> TreeIteratorBase<Value, Children>
+    for PruneDepth<Value, Children, Inner>
+where
+    Inner: TreeIteratorBase<Value, Children>,
+{
+    fn current_path(&self) -> &[usize] {
+        // Since PruneDepth prunes everything at the
+        // same depth level, its paths will always
+        // match those on the inner iterator
+        self.inner.current_path()
+    }
+
+    fn prune_current_subtree(&mut self) {
+        self.inner.prune_current_subtree()
+    }
+}
+
+impl<Value, Children, Inner> TreeIterator<Value, Children> for PruneDepth<Value, Children, Inner> where
+    Inner: TreeIterator<Value, Children>
+{
+}
+
+impl<Value, Children, Inner> BinaryTreeIterator<Value, Children>
+    for PruneDepth<Value, Children, Inner>
+where
+    Inner: BinaryTreeIterator<Value, Children>,
+{
+}

--- a/src/tree_iterators/prune_path.rs
+++ b/src/tree_iterators/prune_path.rs
@@ -1,0 +1,210 @@
+use core::marker::PhantomData;
+
+use alloc::vec::Vec;
+
+use super::{BinaryTreeIterator, TreeIterator, TreeIteratorBase};
+
+pub struct PrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+    phantom1: PhantomData<Value>,
+    phantom2: PhantomData<Children>,
+    inner: InnerIter,
+    f: F,
+    pruned_at_each_depth: Vec<usize>,
+    current_path: Vec<usize>,
+}
+
+impl<Value, Children, InnerIter, F> PrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+    pub(crate) fn new(iter: InnerIter, f: F) -> Self {
+        Self {
+            phantom1: Default::default(),
+            phantom2: Default::default(),
+            inner: iter,
+            f,
+            pruned_at_each_depth: Vec::new(),
+            current_path: Vec::new(),
+        }
+    }
+}
+
+impl<Value, Children, InnerIter, F> Iterator for PrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(item) = self.inner.next() {
+            let inner_depth = self.inner.current_depth();
+
+            if self.pruned_at_each_depth.len() < inner_depth {
+                self.pruned_at_each_depth.push(0);
+                self.current_path.push(0);
+            }
+
+            let mut matched_up_to_depth = 0;
+            let inner_path = self.inner.current_path();
+
+            loop {
+                if matched_up_to_depth >= inner_path.len() {
+                    self.current_path.truncate(matched_up_to_depth);
+                    break;
+                }
+
+                let current_path_at_depth = self.current_path[matched_up_to_depth];
+                let pruned_at_depth = self.pruned_at_each_depth[matched_up_to_depth];
+                let inner_path_at_depth = inner_path[matched_up_to_depth];
+                if (current_path_at_depth + pruned_at_depth) != inner_path_at_depth {
+                    self.pruned_at_each_depth.truncate(matched_up_to_depth + 1);
+                    self.current_path.truncate(matched_up_to_depth);
+                    break;
+                }
+
+                matched_up_to_depth += 1;
+            }
+
+            for depth in matched_up_to_depth..inner_depth {
+                let inner_path_at_depth = inner_path[depth];
+                if self.pruned_at_each_depth.len() == depth {
+                    self.pruned_at_each_depth.push(0);
+                }
+                let pruned_at_depth = self.pruned_at_each_depth[depth];
+                self.current_path
+                    .push(inner_path_at_depth - pruned_at_depth);
+            }
+
+            let path = &self.current_path;
+            if (&mut self.f)(&path, &item) {
+                self.prune_current_subtree();
+                let current_depth = self.current_depth();
+                if current_depth > 0 {
+                    let pruned_at_current_depth = &mut self.pruned_at_each_depth[current_depth - 1];
+                    *pruned_at_current_depth += 1;
+                }
+                continue;
+            }
+
+            return Some(item);
+        }
+
+        self.current_path.clear();
+        self.current_path.shrink_to_fit();
+        None
+    }
+}
+
+impl<Value, Children, InnerIter, F> crate::Sealed for PrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+}
+
+impl<Value, Children, InnerIter, F> TreeIteratorBase<Value, Children>
+    for PrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+    fn current_path(&self) -> &[usize] {
+        &self.current_path
+    }
+
+    fn prune_current_subtree(&mut self) {
+        self.inner.prune_current_subtree();
+    }
+}
+
+impl<Value, Children, InnerIter, F> TreeIterator<Value, Children>
+    for PrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: TreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+}
+
+pub struct BinaryPrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+    phantom1: PhantomData<Value>,
+    phantom2: PhantomData<Children>,
+    inner: InnerIter,
+    f: F,
+}
+
+impl<Value, Children, InnerIter, F> BinaryPrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+    pub(crate) fn new(iter: InnerIter, f: F) -> Self {
+        Self {
+            phantom1: Default::default(),
+            phantom2: Default::default(),
+            inner: iter,
+            f,
+        }
+    }
+}
+
+impl<Value, Children, InnerIter, F> Iterator for BinaryPrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(item) = self.inner.next() {
+            let path = &self.inner.current_path();
+            if (&mut self.f)(&path, &item) {
+                self.prune_current_subtree();
+                continue;
+            }
+
+            return Some(item);
+        }
+
+        None
+    }
+}
+
+impl<Value, Children, InnerIter, F> crate::Sealed for BinaryPrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+}
+
+impl<Value, Children, InnerIter, F> TreeIteratorBase<Value, Children>
+    for BinaryPrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+    fn current_path(&self) -> &[usize] {
+        self.inner.current_path()
+    }
+
+    fn prune_current_subtree(&mut self) {
+        self.inner.prune_current_subtree();
+    }
+}
+
+impl<Value, Children, InnerIter, F> BinaryTreeIterator<Value, Children>
+    for BinaryPrunePath<Value, Children, InnerIter, F>
+where
+    InnerIter: BinaryTreeIterator<Value, Children>,
+    F: FnMut(&[usize], &Value) -> bool,
+{
+}


### PR DESCRIPTION
These changes add the prune, map, and fold methods to the various Tree trait types.

- Prune allows for filter-like operations to be done on trees.
- Map is pretty self-explanatory. Maps one tree into another.
- Fold allows a caller to reduce an entire tree down to a single value fairly trivially.