### PR TITLE
Add collection of tree APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "tree_iterators_rs"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree_iterators_rs"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 description = "tree_iterators_rs is a library built to provide you with the iterators to easily work with tree data structures in Rust."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -88,8 +88,26 @@ into other iterators by chaining one of the following methods:
 
 ## Change Log
 
+- 3.2.0
+  - Adds the IntoIteratorOfTrees and IntoIteratorOfBinaryTrees traits for more
+    easily working with collections of trees. A default implementation of all
+    functionality is provided for [`Vec`](alloc::vec::Vec) and
+    [`[T]`](core::array) types. The new traits include:
+    - [`OwnedIntoIteratorOfTrees`](crate::prelude::OwnedIntoIteratorOfTrees)
+    - [`OwnedIntoIteratorOfBinaryTrees`](crate::prelude::OwnedIntoIteratorOfBinaryTrees)
+    - [`MutBorrowedIntoIteratorOfTrees`](crate::prelude::MutBorrowedIntoIteratorOfTrees)
+    - [`MutBorrowedIntoIteratorOfBinaryTrees`](crate::prelude::MutBorrowedIntoIteratorOfBinaryTrees)
+    - [`BorrowedIntoIteratorOfTrees`](crate::prelude::BorrowedIntoIteratorOfTrees)
+    - [`BorrowedIntoIteratorOfBinaryTrees`](crate::prelude::BorrowedIntoIteratorOfBinaryTrees)
+  - Additionally, each of these traits' iteration APIs allow calling
+    .attach_context(). These IntoIterator-based .attach_context() calls will
+    track the index in the IntoIteratorOfTrees as part of the path provided in
+    the [`TreeContext`](crate::prelude::TreeContext)
+
 - 3.1.0
-  - Adds the [prune](crate::prelude::OwnedTreeNode::prune), [map](crate::prelude::OwnedTreeNode::map), and [fold](crate::prelude::OwnedTreeNode::fold) methods to all Tree traits.
+  - Adds the [prune](crate::prelude::OwnedTreeNode::prune),
+    [map](crate::prelude::OwnedTreeNode::map), and
+    [fold](crate::prelude::OwnedTreeNode::fold) methods to all Tree traits.
   > **_NOTE_**: These are named `_mut` or `_ref` for the borrowed traits
 
 - 3.0.0

--- a/doc_files/collection_attach_context.md
+++ b/doc_files/collection_attach_context.md
@@ -1,0 +1,97 @@
+This method will panic if called after an element has already been yielded from
+the iterator it is called on! This method attaches the entire context of where a
+node is in the tree to the node during iteration. This operation converts the
+current iterator into a streaming iterator. For Breadth First Search iterators,
+this converts the queue-based iterator into an iterative deepening iterator.
+This can have performance impacts, as iterative deepening visits many of the
+nodes in the tree more than once. The order in which elements are yielded
+remains unchanged. The context provided includes:
+
+1. the entire stack of ancestor values back up to the root node
+2. the current node's children collection (except in the case of owned
+   dfs_inorder and dfs_postorder APIs, which can't hold onto this information
+   without causing performance issues by clone()'ing).
+3. the path (list of indexes) to get to the current node. **This includes the**
+   **index into the collection of trees as the first index in the list**.
+
+### Example Usage
+
+One use case for the `attach_context()` API is to loop through each node in the
+tree and check if its subtree meets a condition. In this case, we are scanning
+for all subtrees that contain the '10' node.
+
+```text
+Example Tree:
+       0
+      / \
+     1   2
+    / \ / \
+   3  4 5  6
+          /
+         7
+          \
+           8
+          /
+         9
+          \
+          10
+```
+
+```rust
+use tree_iterators_rs::examples::create_example_tree;
+use tree_iterators_rs::prelude::*;
+use streaming_iterator::StreamingIterator;
+
+let root = vec![
+    create_example_tree(),
+    create_example_tree(),
+    create_example_tree()
+];
+
+let mut iter = root
+    .dfs_preorder_each()
+    .attach_context();
+
+while let Some(node_context) = iter.next() {
+    let current_node_is_10 = *node_context
+        .ancestors()
+        .last()
+        .expect("ancestors() is guaranteed to be non-empty")
+        == 10;
+
+    let any_descendent_is_10 = node_context
+        .children()
+        .iter()
+        .flat_map(|child| child.dfs_preorder_iter())
+        .any(|descendent| *descendent == 10);
+
+    let subtree_contains_10 = current_node_is_10 || any_descendent_is_10;
+
+    println!("{:?} {}", node_context.ancestors(), subtree_contains_10);
+}
+
+// Results:
+// [0] true
+// [0, 1] false
+// [0, 1, 3] false
+// [0, 1, 4] false
+// [0, 2] true
+// [0, 2, 5] false
+// [0, 2, 6] true
+// [0, 2, 6, 7] true
+// [0, 2, 6, 7, 8] true
+// [0, 2, 6, 7, 8, 9] true
+// [0, 2, 6, 7, 8, 9, 10] true
+```
+
+### More Technical Details
+
+Because this operation transforms the iterator into a StreamingIterator, the
+context cannot be saved and used across loop iterations, as the context contains
+internal iterator state and is altered with the .next() call. Each slice must be
+collected into a Vec or other data structure by the caller to save them for
+later. This operation will incur a performance penalty and this library does not
+assume you want that performance penalty by default. Since this iterator is no
+longer a Rust Iterator, for loops will no longer work. See details on how to
+work around this in the
+[streaming-iterator](https://crates.io/crates/streaming-iterator) crate.

--- a/src/bfs_iterators/borrow.rs
+++ b/src/bfs_iterators/borrow.rs
@@ -18,6 +18,29 @@ use super::{
     bfs_context_streaming_iterator_impl, bfs_next, TreeNodeVecDeque,
 };
 
+crate::collection_iterators::borrowed_collection_iterator_impl!(
+    BorrowedBFSCollectionIterator,
+    BorrowedBFSIterator,
+    BorrowedTreeNode
+);
+
+impl<'a, IntoIter, Node> BorrowedBFSCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a Node>,
+    Node: BorrowedTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(self) -> BorrowedBFSCollectionIteratorWithContext<'a, IntoIter, Node> {
+        BorrowedBFSCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::borrowed_collection_context_iterator_impl!(
+    BorrowedBFSCollectionIteratorWithContext,
+    BorrowedBFSIteratorWithContext,
+    BorrowedBFSCollectionIterator
+);
+
 pub struct BorrowedBFSIterator<'a, Node>
 where
     Node: BorrowedTreeNode<'a>,
@@ -50,7 +73,7 @@ where
     pub fn attach_context(self) -> BorrowedBFSIteratorWithContext<'a, Node> {
         match self.root {
             None => panic!("Attempted to attach metadata to a BFS iterator in the middle of a tree traversal. This is forbidden."),
-            Some(root) => BorrowedBFSIteratorWithContext::new(root)
+            Some(root) => BorrowedBFSIteratorWithContext::new(root, Vec::new())
         }
     }
 
@@ -87,14 +110,17 @@ impl<'a, Node> BorrowedBFSIteratorWithContext<'a, Node>
 where
     Node: BorrowedTreeNode<'a>,
 {
-    fn new(root: &'a Node) -> Self {
+    fn new(root: &'a Node, path: Vec<usize>) -> Self {
         let (value, children) = root.get_value_and_children_iter();
         let tree_cache = TreeNodeVecDeque::default();
 
         let iterator_queue = VecDeque::new();
-        let mut current_context = TreeContext::new();
+        let mut current_context = TreeContext {
+            path,
+            ancestors: Vec::new(),
+            children: Some(children),
+        };
         current_context.ancestors.push(value);
-        current_context.children = Some(children);
 
         BorrowedBFSIteratorWithContext {
             is_root: true,
@@ -178,6 +204,31 @@ where
     bfs_ancestors_streaming_iterator_impl!(get_value_and_children_iter);
 }
 
+crate::collection_iterators::borrowed_collection_iterator_impl!(
+    BorrowedBinaryBFSCollectionIterator,
+    BorrowedBinaryBFSIterator,
+    BorrowedBinaryTreeNode
+);
+
+impl<'a, IntoIter, Node> BorrowedBinaryBFSCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a Node>,
+    Node: BorrowedBinaryTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(
+        self,
+    ) -> BorrowedBinaryBFSCollectionIteratorWithContext<'a, IntoIter, Node> {
+        BorrowedBinaryBFSCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::borrowed_binary_collection_context_iterator_impl!(
+    BorrowedBinaryBFSCollectionIteratorWithContext,
+    BorrowedBinaryBFSIteratorWithContext,
+    BorrowedBinaryBFSCollectionIterator
+);
+
 pub struct BorrowedBinaryBFSIterator<'a, Node>
 where
     Node: BorrowedBinaryTreeNode<'a>,
@@ -210,7 +261,7 @@ where
     pub fn attach_context(self) -> BorrowedBinaryBFSIteratorWithContext<'a, Node> {
         match self.root {
             None => panic!("Attempted to attach metadata to a BFS iterator in the middle of a tree traversal. This is forbidden."),
-            Some(root) => BorrowedBinaryBFSIteratorWithContext::new(root)
+            Some(root) => BorrowedBinaryBFSIteratorWithContext::new(root, Vec::new())
         }
     }
 
@@ -297,14 +348,17 @@ impl<'a, Node> BorrowedBinaryBFSIteratorWithContext<'a, Node>
 where
     Node: BorrowedBinaryTreeNode<'a>,
 {
-    fn new(root: &'a Node) -> Self {
+    fn new(root: &'a Node, path: Vec<usize>) -> Self {
         let (value, children) = root.get_value_and_children_binary_iter();
         let tree_cache = TreeNodeVecDeque::default();
 
         let iterator_queue = VecDeque::new();
-        let mut current_context = TreeContext::new();
+        let mut current_context = TreeContext {
+            path,
+            ancestors: Vec::new(),
+            children: Some(children),
+        };
         current_context.ancestors.push(value);
-        current_context.children = Some(children);
 
         Self {
             is_root: true,

--- a/src/bfs_iterators/mut_borrow.rs
+++ b/src/bfs_iterators/mut_borrow.rs
@@ -20,6 +20,29 @@ use crate::{
     prelude::{BinaryChildren, MutBorrowedBinaryTreeNode, MutBorrowedTreeNode, TreeContext},
 };
 
+crate::collection_iterators::mut_borrowed_collection_iterator_impl!(
+    MutBorrowedBFSCollectionIterator,
+    MutBorrowedBFSIterator,
+    MutBorrowedTreeNode
+);
+
+impl<'a, IntoIter, Node> MutBorrowedBFSCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a mut Node>,
+    Node: MutBorrowedTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(self) -> MutBorrowedBFSCollectionIteratorWithContext<'a, IntoIter, Node> {
+        MutBorrowedBFSCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::mut_borrowed_collection_context_iterator_impl!(
+    MutBorrowedBFSCollectionIteratorWithContext,
+    MutBorrowedBFSIteratorWithContext,
+    MutBorrowedBFSCollectionIterator
+);
+
 pub struct MutBorrowedBFSIterator<'a, Node>
 where
     Node: MutBorrowedTreeNode<'a>,
@@ -52,7 +75,7 @@ where
     pub fn attach_context(self) -> MutBorrowedBFSIteratorWithContext<'a, Node> {
         match self.root {
             None => panic!("Attempted to attach metadata to a BFS iterator in the middle of a tree traversal. This is forbidden."),
-            Some(root) => MutBorrowedBFSIteratorWithContext::new(root)
+            Some(root) => MutBorrowedBFSIteratorWithContext::new(root, Vec::new())
         }
     }
 
@@ -89,13 +112,16 @@ impl<'a, Node> MutBorrowedBFSIteratorWithContext<'a, Node>
 where
     Node: MutBorrowedTreeNode<'a>,
 {
-    fn new(root: &'a mut Node) -> MutBorrowedBFSIteratorWithContext<'a, Node> {
+    fn new(root: &'a mut Node, path: Vec<usize>) -> MutBorrowedBFSIteratorWithContext<'a, Node> {
         let (value, children) = root.get_value_and_children_iter_mut();
         let tree_cache = TreeNodeVecDeque::default();
         let iterator_queue = VecDeque::new();
-        let mut current_context = TreeContext::new();
+        let mut current_context = TreeContext {
+            path,
+            ancestors: Vec::new(),
+            children: Some(children),
+        };
         current_context.ancestors.push(value);
-        current_context.children = Some(children);
 
         MutBorrowedBFSIteratorWithContext {
             is_root: true,
@@ -193,6 +219,31 @@ where
     get_mut_ancestors!();
 }
 
+crate::collection_iterators::mut_borrowed_collection_iterator_impl!(
+    MutBorrowedBinaryBFSCollectionIterator,
+    MutBorrowedBinaryBFSIterator,
+    MutBorrowedBinaryTreeNode
+);
+
+impl<'a, IntoIter, Node> MutBorrowedBinaryBFSCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a mut Node>,
+    Node: MutBorrowedBinaryTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(
+        self,
+    ) -> MutBorrowedBinaryBFSCollectionIteratorWithContext<'a, IntoIter, Node> {
+        MutBorrowedBinaryBFSCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::mut_borrowed_binary_collection_context_iterator_impl!(
+    MutBorrowedBinaryBFSCollectionIteratorWithContext,
+    MutBorrowedBinaryBFSIteratorWithContext,
+    MutBorrowedBinaryBFSCollectionIterator
+);
+
 pub struct MutBorrowedBinaryBFSIterator<'a, Node>
 where
     Node: MutBorrowedBinaryTreeNode<'a>,
@@ -225,7 +276,7 @@ where
     pub fn attach_context(self) -> MutBorrowedBinaryBFSIteratorWithContext<'a, Node> {
         match self.root {
             None => panic!("Attempted to attach metadata to a BFS iterator in the middle of a tree traversal. This is forbidden."),
-            Some(root) => MutBorrowedBinaryBFSIteratorWithContext::new(root)
+            Some(root) => MutBorrowedBinaryBFSIteratorWithContext::new(root, Vec::new())
         }
     }
 
@@ -319,14 +370,17 @@ impl<'a, Node> MutBorrowedBinaryBFSIteratorWithContext<'a, Node>
 where
     Node: MutBorrowedBinaryTreeNode<'a>,
 {
-    fn new(root: &'a mut Node) -> Self {
+    fn new(root: &'a mut Node, path: Vec<usize>) -> Self {
         let (value, children) = root.get_value_and_children_binary_iter_mut();
         let tree_cache = TreeNodeVecDeque::default();
 
         let iterator_queue = VecDeque::new();
-        let mut current_context = TreeContext::new();
+        let mut current_context = TreeContext {
+            path,
+            ancestors: Vec::new(),
+            children: Some(children),
+        };
         current_context.ancestors.push(value);
-        current_context.children = Some(children);
 
         Self {
             is_root: true,

--- a/src/collection_iterators.rs
+++ b/src/collection_iterators.rs
@@ -1,0 +1,881 @@
+macro_rules! owned_collection_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $tree_trait: ident) => {
+        pub struct $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: $tree_trait,
+        {
+            collection: IntoIter::IntoIter,
+            tree_traversal_iterator: Option<$inner_iterator<IntoIter::Item>>,
+        }
+
+        impl<IntoIter> $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: $tree_trait,
+        {
+            pub(crate) fn new(into_iter: IntoIter) -> Self {
+                Self {
+                    collection: into_iter.into_iter(),
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<IntoIter> Iterator for $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: $tree_trait,
+        {
+            type Item = <IntoIter::Item as $tree_trait>::OwnedValue;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return next;
+                        }
+                    }
+
+                    self.tree_traversal_iterator = self
+                        .collection
+                        .next()
+                        .map(|item| $inner_iterator::new(item));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return None;
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! owned_collection_context_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $source: ident) => {
+       pub struct $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedTreeNode,
+        {
+            collection: IntoIter::IntoIter,
+            index: usize,
+            tree_traversal_iterator: Option<$inner_iterator<IntoIter::Item>>,
+        }
+
+        impl<IntoIter> $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedTreeNode,
+        {
+            fn new(source: $source<IntoIter>) -> Self {
+                if source.tree_traversal_iterator.is_some() {
+                    panic!("Cannot attach metadata to BFS collection iterator after .next() has been called.");
+                }
+
+                Self {
+                    collection: source.collection,
+                    index: usize::MAX,
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<IntoIter> StreamingIterator for $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedTreeNode,
+        {
+            type Item = TreeContext<
+                <IntoIter::Item as OwnedTreeNode>::OwnedValue,
+                <IntoIter::Item as OwnedTreeNode>::OwnedChildren,
+            >;
+
+            fn advance(&mut self) {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return;
+                        }
+                    }
+
+                    let next_tree_iterator = self
+                        .collection
+                        .next();
+
+                    let mut path_with_index = if let Some(tree_iterator) = self.tree_traversal_iterator.as_ref() {
+                        Vec::with_capacity(tree_iterator.current_context.path.capacity())
+                    } else {
+                        Vec::new()
+                    };
+
+                    self.index = self.index.wrapping_add(1);
+                    path_with_index.push(self.index);
+
+                    self.tree_traversal_iterator = next_tree_iterator
+                        .map(|item| $inner_iterator::new(item, path_with_index));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return;
+                    }
+                }
+            }
+
+            fn get(&self) -> Option<&Self::Item> {
+                self.tree_traversal_iterator
+                    .as_ref()
+                    .and_then(|iter| iter.get())
+            }
+        }
+
+        impl<IntoIter> StreamingIteratorMut for $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedTreeNode,
+        {
+            fn get_mut(&mut self) -> Option<&mut Self::Item> {
+                self.tree_traversal_iterator
+                    .as_mut()
+                    .and_then(|iter| iter.get_mut())
+            }
+        }
+    };
+}
+
+macro_rules! owned_collection_context_no_children_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $source: ident) => {
+       pub struct $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedTreeNode,
+        {
+            collection: IntoIter::IntoIter,
+            index: usize,
+            tree_traversal_iterator: Option<$inner_iterator<IntoIter::Item>>,
+        }
+
+        impl<IntoIter> $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedTreeNode,
+        {
+            fn new(source: $source<IntoIter>) -> Self {
+                if source.tree_traversal_iterator.is_some() {
+                    panic!("Cannot attach metadata to BFS collection iterator after .next() has been called.");
+                }
+
+                Self {
+                    collection: source.collection,
+                    index: usize::MAX,
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<IntoIter> StreamingIterator for $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedTreeNode,
+        {
+            type Item = TreeContext<
+                <IntoIter::Item as OwnedTreeNode>::OwnedValue,
+                ()
+            >;
+
+            fn advance(&mut self) {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return;
+                        }
+                    }
+
+                    let next_tree_iterator = self
+                        .collection
+                        .next();
+
+                    let mut path_with_index = if let Some(tree_iterator) = self.tree_traversal_iterator.as_ref() {
+                        Vec::with_capacity(tree_iterator.current_context.path.capacity())
+                    } else {
+                        Vec::new()
+                    };
+
+                    self.index = self.index.wrapping_add(1);
+                    path_with_index.push(self.index);
+
+                    self.tree_traversal_iterator = next_tree_iterator
+                        .map(|item| $inner_iterator::new(item, path_with_index));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return;
+                    }
+                }
+            }
+
+            fn get(&self) -> Option<&Self::Item> {
+                self.tree_traversal_iterator
+                    .as_ref()
+                    .and_then(|iter| iter.get())
+            }
+        }
+
+        impl<IntoIter> StreamingIteratorMut for $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedTreeNode,
+        {
+            fn get_mut(&mut self) -> Option<&mut Self::Item> {
+                self.tree_traversal_iterator
+                    .as_mut()
+                    .and_then(|iter| iter.get_mut())
+            }
+        }
+    };
+}
+
+macro_rules! owned_collection_binary_context_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $source: ident) => {
+        pub struct $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedBinaryTreeNode,
+        {
+            collection: IntoIter::IntoIter,
+            index: usize,
+            tree_traversal_iterator: Option<$inner_iterator<IntoIter::Item>>,
+        }
+
+        impl<IntoIter> $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedBinaryTreeNode,
+        {
+            fn new(source: $source<IntoIter>) -> Self {
+                if source.tree_traversal_iterator.is_some() {
+                    panic!("Cannot attach metadata after .next() has been called.");
+                }
+
+                Self {
+                    collection: source.collection,
+                    index: usize::MAX,
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<IntoIter> StreamingIterator for $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedBinaryTreeNode,
+        {
+            type Item = TreeContext<
+                <IntoIter::Item as OwnedBinaryTreeNode>::OwnedValue,
+                [Option<IntoIter::Item>; 2],
+            >;
+
+            fn advance(&mut self) {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return;
+                        }
+                    }
+
+                    let next_tree_iterator = self.collection.next();
+
+                    let mut path_with_index =
+                        if let Some(tree_iterator) = self.tree_traversal_iterator.as_ref() {
+                            Vec::with_capacity(tree_iterator.current_context.path.capacity())
+                        } else {
+                            Vec::new()
+                        };
+
+                    self.index = self.index.wrapping_add(1);
+                    path_with_index.push(self.index);
+
+                    self.tree_traversal_iterator =
+                        next_tree_iterator.map(|item| $inner_iterator::new(item, path_with_index));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return;
+                    }
+                }
+            }
+
+            fn get(&self) -> Option<&Self::Item> {
+                self.tree_traversal_iterator
+                    .as_ref()
+                    .and_then(|iter| iter.get())
+            }
+        }
+
+        impl<IntoIter> StreamingIteratorMut for $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedBinaryTreeNode,
+        {
+            fn get_mut(&mut self) -> Option<&mut Self::Item> {
+                self.tree_traversal_iterator
+                    .as_mut()
+                    .and_then(|iter| iter.get_mut())
+            }
+        }
+    };
+}
+
+macro_rules! owned_collection_binary_context_no_children_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $source: ident) => {
+        pub struct $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedBinaryTreeNode,
+        {
+            collection: IntoIter::IntoIter,
+            index: usize,
+            tree_traversal_iterator: Option<$inner_iterator<IntoIter::Item>>,
+        }
+
+        impl<IntoIter> $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedBinaryTreeNode,
+        {
+            fn new(source: $source<IntoIter>) -> Self {
+                if source.tree_traversal_iterator.is_some() {
+                    panic!("Cannot attach metadata after .next() has been called.");
+                }
+
+                Self {
+                    collection: source.collection,
+                    index: usize::MAX,
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<IntoIter> StreamingIterator for $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedBinaryTreeNode,
+        {
+            type Item = TreeContext<<IntoIter::Item as OwnedBinaryTreeNode>::OwnedValue, ()>;
+
+            fn advance(&mut self) {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return;
+                        }
+                    }
+
+                    let next_tree_iterator = self.collection.next();
+
+                    let mut path_with_index =
+                        if let Some(tree_iterator) = self.tree_traversal_iterator.as_ref() {
+                            Vec::with_capacity(tree_iterator.current_context.path.capacity())
+                        } else {
+                            Vec::new()
+                        };
+
+                    self.index = self.index.wrapping_add(1);
+                    path_with_index.push(self.index);
+
+                    self.tree_traversal_iterator =
+                        next_tree_iterator.map(|item| $inner_iterator::new(item, path_with_index));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return;
+                    }
+                }
+            }
+
+            fn get(&self) -> Option<&Self::Item> {
+                self.tree_traversal_iterator
+                    .as_ref()
+                    .and_then(|iter| iter.get())
+            }
+        }
+
+        impl<IntoIter> StreamingIteratorMut for $struct_name<IntoIter>
+        where
+            IntoIter: IntoIterator,
+            IntoIter::Item: OwnedBinaryTreeNode,
+        {
+            fn get_mut(&mut self) -> Option<&mut Self::Item> {
+                self.tree_traversal_iterator
+                    .as_mut()
+                    .and_then(|iter| iter.get_mut())
+            }
+        }
+    };
+}
+
+macro_rules! mut_borrowed_collection_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $tree_trait: tt) => {
+        pub struct $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: $tree_trait<'a>,
+        {
+            collection: IntoIter::IntoIter,
+            tree_traversal_iterator: Option<$inner_iterator<'a, Node>>,
+        }
+
+        impl<'a, IntoIter, Node> $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: $tree_trait<'a>,
+        {
+            pub(crate) fn new(into_iter: IntoIter) -> Self {
+                Self {
+                    collection: into_iter.into_iter(),
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<'a, IntoIter, Node> Iterator for $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: $tree_trait<'a>,
+        {
+            type Item = Node::MutBorrowedValue;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return next;
+                        }
+                    }
+
+                    self.tree_traversal_iterator = self
+                        .collection
+                        .next()
+                        .map(|item| $inner_iterator::new(item));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return None;
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! mut_borrowed_collection_context_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $source: ident) => {
+       pub struct $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: MutBorrowedTreeNode<'a>,
+        {
+            collection: IntoIter::IntoIter,
+            index: usize,
+            tree_traversal_iterator: Option<$inner_iterator<'a, Node>>,
+        }
+
+        impl<'a, IntoIter, Node> $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: MutBorrowedTreeNode<'a>,
+        {
+            fn new(source: $source<'a, IntoIter, Node>) -> Self {
+                if source.tree_traversal_iterator.is_some() {
+                    panic!("Cannot attach metadata to BFS collection iterator after .next() has been called.");
+                }
+
+                Self {
+                    collection: source.collection,
+                    index: usize::MAX,
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<'a, IntoIter, Node> StreamingIterator for $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: MutBorrowedTreeNode<'a>,
+        {
+            type Item = TreeContext<
+                Node::MutBorrowedValue,
+                Node::MutBorrowedChildren,
+            >;
+
+            fn advance(&mut self) {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return;
+                        }
+                    }
+
+                    let next_tree_iterator = self
+                        .collection
+                        .next();
+
+                    let mut path_with_index = if let Some(tree_iterator) = self.tree_traversal_iterator.as_ref() {
+                        Vec::with_capacity(tree_iterator.current_context.path.capacity())
+                    } else {
+                        Vec::new()
+                    };
+
+                    self.index = self.index.wrapping_add(1);
+                    path_with_index.push(self.index);
+
+                    self.tree_traversal_iterator = next_tree_iterator
+                        .map(|item| $inner_iterator::new(item, path_with_index));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return;
+                    }
+                }
+            }
+
+            fn get(&self) -> Option<&Self::Item> {
+                self.tree_traversal_iterator
+                    .as_ref()
+                    .and_then(|iter| iter.get())
+            }
+        }
+
+        impl<'a, IntoIter, Node> StreamingIteratorMut for $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: MutBorrowedTreeNode<'a>,
+        {
+            fn get_mut(&mut self) -> Option<&mut Self::Item> {
+                self.tree_traversal_iterator
+                    .as_mut()
+                    .and_then(|iter| iter.get_mut())
+            }
+        }
+    };
+}
+
+macro_rules! borrowed_binary_collection_context_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $source: ident) => {
+       pub struct $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a Node>,
+            Node: BorrowedBinaryTreeNode<'a>,
+        {
+            collection: IntoIter::IntoIter,
+            index: usize,
+            tree_traversal_iterator: Option<$inner_iterator<'a, Node>>,
+        }
+
+        impl<'a, IntoIter, Node> $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a Node>,
+            Node: BorrowedBinaryTreeNode<'a>,
+        {
+            fn new(source: $source<'a, IntoIter, Node>) -> Self {
+                if source.tree_traversal_iterator.is_some() {
+                    panic!("Cannot attach metadata to BFS collection iterator after .next() has been called.");
+                }
+
+                Self {
+                    collection: source.collection,
+                    index: usize::MAX,
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<'a, IntoIter, Node> StreamingIterator for $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a Node>,
+            Node: BorrowedBinaryTreeNode<'a>,
+        {
+            type Item = TreeContext<
+                Node::BorrowedValue,
+                [Option<&'a Node>; 2]
+            >;
+
+            fn advance(&mut self) {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return;
+                        }
+                    }
+
+                    let next_tree_iterator = self
+                        .collection
+                        .next();
+
+                    let mut path_with_index = if let Some(tree_iterator) = self.tree_traversal_iterator.as_ref() {
+                        Vec::with_capacity(tree_iterator.current_context.path.capacity())
+                    } else {
+                        Vec::new()
+                    };
+
+                    self.index = self.index.wrapping_add(1);
+                    path_with_index.push(self.index);
+
+                    self.tree_traversal_iterator = next_tree_iterator
+                        .map(|item| $inner_iterator::new(item, path_with_index));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return;
+                    }
+                }
+            }
+
+            fn get(&self) -> Option<&Self::Item> {
+                self.tree_traversal_iterator
+                    .as_ref()
+                    .and_then(|iter| iter.get())
+            }
+        }
+    };
+}
+
+macro_rules! borrowed_collection_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $tree_trait: tt) => {
+        pub struct $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a Node>,
+            Node: $tree_trait<'a>,
+        {
+            collection: IntoIter::IntoIter,
+            tree_traversal_iterator: Option<$inner_iterator<'a, Node>>,
+        }
+
+        impl<'a, IntoIter, Node> $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a Node>,
+            Node: $tree_trait<'a>,
+        {
+            pub(crate) fn new(into_iter: IntoIter) -> Self {
+                Self {
+                    collection: into_iter.into_iter(),
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<'a, IntoIter, Node> Iterator for $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a Node>,
+            Node: $tree_trait<'a>,
+        {
+            type Item = Node::BorrowedValue;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return next;
+                        }
+                    }
+
+                    self.tree_traversal_iterator = self
+                        .collection
+                        .next()
+                        .map(|item| $inner_iterator::new(item));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return None;
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! borrowed_collection_context_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $source: ident) => {
+       pub struct $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a Node>,
+            Node: BorrowedTreeNode<'a>,
+        {
+            collection: IntoIter::IntoIter,
+            index: usize,
+            tree_traversal_iterator: Option<$inner_iterator<'a, Node>>,
+        }
+
+        impl<'a, IntoIter, Node> $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a Node>,
+            Node: BorrowedTreeNode<'a>,
+        {
+            fn new(source: $source<'a, IntoIter, Node>) -> Self {
+                if source.tree_traversal_iterator.is_some() {
+                    panic!("Cannot attach metadata to BFS collection iterator after .next() has been called.");
+                }
+
+                Self {
+                    collection: source.collection,
+                    index: usize::MAX,
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<'a, IntoIter, Node> StreamingIterator for $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a Node>,
+            Node: BorrowedTreeNode<'a>,
+        {
+            type Item = TreeContext<
+                Node::BorrowedValue,
+                Node::BorrowedChildren,
+            >;
+
+            fn advance(&mut self) {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return;
+                        }
+                    }
+
+                    let next_tree_iterator = self
+                        .collection
+                        .next();
+
+                    let mut path_with_index = if let Some(tree_iterator) = self.tree_traversal_iterator.as_ref() {
+                        Vec::with_capacity(tree_iterator.current_context.path.capacity())
+                    } else {
+                        Vec::new()
+                    };
+
+                    self.index = self.index.wrapping_add(1);
+                    path_with_index.push(self.index);
+
+                    self.tree_traversal_iterator = next_tree_iterator
+                        .map(|item| $inner_iterator::new(item, path_with_index));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return;
+                    }
+                }
+            }
+
+            fn get(&self) -> Option<&Self::Item> {
+                self.tree_traversal_iterator
+                    .as_ref()
+                    .and_then(|iter| iter.get())
+            }
+        }
+    };
+}
+
+macro_rules! mut_borrowed_binary_collection_context_iterator_impl {
+    ($struct_name: ident, $inner_iterator: ident, $source: ident) => {
+       pub struct $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: MutBorrowedBinaryTreeNode<'a>,
+        {
+            collection: IntoIter::IntoIter,
+            index: usize,
+            tree_traversal_iterator: Option<$inner_iterator<'a, Node>>,
+        }
+
+        impl<'a, IntoIter, Node> $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: MutBorrowedBinaryTreeNode<'a>,
+        {
+            fn new(source: $source<'a, IntoIter, Node>) -> Self {
+                if source.tree_traversal_iterator.is_some() {
+                    panic!("Cannot attach metadata to BFS collection iterator after .next() has been called.");
+                }
+
+                Self {
+                    collection: source.collection,
+                    index: usize::MAX,
+                    tree_traversal_iterator: None,
+                }
+            }
+        }
+
+        impl<'a, IntoIter, Node> StreamingIterator for $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: MutBorrowedBinaryTreeNode<'a>,
+        {
+            type Item = TreeContext<
+                Node::MutBorrowedValue,
+                [Option<&'a mut Node>; 2]
+            >;
+
+            fn advance(&mut self) {
+                loop {
+                    if let Some(iter) = self.tree_traversal_iterator.as_mut() {
+                        let next = iter.next();
+                        if next.is_some() {
+                            return;
+                        }
+                    }
+
+                    let next_tree_iterator = self
+                        .collection
+                        .next();
+
+                    let mut path_with_index = if let Some(tree_iterator) = self.tree_traversal_iterator.as_ref() {
+                        Vec::with_capacity(tree_iterator.current_context.path.capacity())
+                    } else {
+                        Vec::new()
+                    };
+
+                    self.index = self.index.wrapping_add(1);
+                    path_with_index.push(self.index);
+
+                    self.tree_traversal_iterator = next_tree_iterator
+                        .map(|item| $inner_iterator::new(item, path_with_index));
+
+                    if self.tree_traversal_iterator.is_none() {
+                        return;
+                    }
+                }
+            }
+
+            fn get(&self) -> Option<&Self::Item> {
+                self.tree_traversal_iterator
+                    .as_ref()
+                    .and_then(|iter| iter.get())
+            }
+        }
+
+        impl<'a, IntoIter, Node> StreamingIteratorMut for $struct_name<'a, IntoIter, Node>
+        where
+            IntoIter: IntoIterator<Item = &'a mut Node>,
+            Node: MutBorrowedBinaryTreeNode<'a>,
+
+        {
+            fn get_mut(&mut self) -> Option<&mut Self::Item> {
+                self.tree_traversal_iterator
+                    .as_mut()
+                    .and_then(|iter| iter.get_mut())
+            }
+        }
+    };
+}
+
+pub(crate) use borrowed_binary_collection_context_iterator_impl;
+pub(crate) use borrowed_collection_context_iterator_impl;
+pub(crate) use borrowed_collection_iterator_impl;
+pub(crate) use mut_borrowed_binary_collection_context_iterator_impl;
+pub(crate) use mut_borrowed_collection_context_iterator_impl;
+pub(crate) use mut_borrowed_collection_iterator_impl;
+pub(crate) use owned_collection_binary_context_iterator_impl;
+pub(crate) use owned_collection_binary_context_no_children_iterator_impl;
+pub(crate) use owned_collection_context_iterator_impl;
+pub(crate) use owned_collection_context_no_children_iterator_impl;
+pub(crate) use owned_collection_iterator_impl;

--- a/src/dfs_inorder_iterators/owned.rs
+++ b/src/dfs_inorder_iterators/owned.rs
@@ -15,6 +15,29 @@ use super::{
     get_mut_context, TraversalStatus,
 };
 
+crate::collection_iterators::owned_collection_iterator_impl!(
+    OwnedDFSInorderCollectionIterator,
+    OwnedDFSInorderIterator,
+    OwnedBinaryTreeNode
+);
+
+impl<IntoIter> OwnedDFSInorderCollectionIterator<IntoIter>
+where
+    IntoIter: IntoIterator,
+    IntoIter::Item: OwnedBinaryTreeNode,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(self) -> OwnedDFSInorderCollectionIteratorWithContext<IntoIter> {
+        OwnedDFSInorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::owned_collection_binary_context_no_children_iterator_impl!(
+    OwnedDFSInorderCollectionIteratorWithContext,
+    OwnedDFSInorderIteratorWithContext,
+    OwnedDFSInorderCollectionIterator
+);
+
 pub struct OwnedDFSInorderIterator<Node>
 where
     Node: OwnedBinaryTreeNode,
@@ -59,7 +82,7 @@ where
         let root = self.right_stack.pop();
         match self.moved {
             true => panic!("Attempted to attach metadata to a DFS in order iterator in the middle of a tree traversal. This is forbidden."),
-            false => OwnedDFSInorderIteratorWithContext::new(root.unwrap().unwrap())
+            false => OwnedDFSInorderIteratorWithContext::new(root.unwrap().unwrap(), Vec::new())
         }
     }
 
@@ -163,11 +186,15 @@ impl<Node> OwnedDFSInorderIteratorWithContext<Node>
 where
     Node: OwnedBinaryTreeNode,
 {
-    pub(crate) fn new(root: Node) -> OwnedDFSInorderIteratorWithContext<Node> {
+    pub(crate) fn new(root: Node, path: Vec<usize>) -> OwnedDFSInorderIteratorWithContext<Node> {
         let mut right_stack = Vec::new();
         right_stack.push(Some(root));
 
-        let context = TreeContext::new();
+        let context = TreeContext {
+            path: path,
+            ancestors: Vec::new(),
+            children: None,
+        };
 
         Self {
             right_stack,

--- a/src/dfs_postorder_iterators/borrow.rs
+++ b/src/dfs_postorder_iterators/borrow.rs
@@ -15,6 +15,31 @@ use streaming_iterator::StreamingIterator;
 
 use super::{dfs_postorder_next, postorder_ancestors_streaming_iterator_impl};
 
+crate::collection_iterators::borrowed_collection_iterator_impl!(
+    BorrowedDFSPostorderCollectionIterator,
+    BorrowedDFSPostorderIterator,
+    BorrowedTreeNode
+);
+
+impl<'a, IntoIter, Node> BorrowedDFSPostorderCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a Node>,
+    Node: BorrowedTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(
+        self,
+    ) -> BorrowedDFSPostorderCollectionIteratorWithContext<'a, IntoIter, Node> {
+        BorrowedDFSPostorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::borrowed_collection_context_iterator_impl!(
+    BorrowedDFSPostorderCollectionIteratorWithContext,
+    BorrowedDFSPostorderIteratorWithContext,
+    BorrowedDFSPostorderCollectionIterator
+);
+
 pub struct BorrowedDFSPostorderIterator<'a, Node>
 where
     Node: BorrowedTreeNode<'a>,
@@ -53,7 +78,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS postorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                BorrowedDFSPostorderIteratorWithContext::new(root)
+                BorrowedDFSPostorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -91,12 +116,16 @@ impl<'a, Node> BorrowedDFSPostorderIteratorWithContext<'a, Node>
 where
     Node: BorrowedTreeNode<'a>,
 {
-    fn new(root: &'a Node) -> BorrowedDFSPostorderIteratorWithContext<'_, Node> {
+    fn new(root: &'a Node, path: Vec<usize>) -> BorrowedDFSPostorderIteratorWithContext<'_, Node> {
         Self {
             root: Some(root),
             traversal_stack: Vec::new(),
             into_iterator_stack: Vec::new(),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
         }
     }
 }
@@ -104,7 +133,6 @@ where
 impl<'a, Node> StreamingIterator for BorrowedDFSPostorderIteratorWithContext<'a, Node>
 where
     Node: BorrowedTreeNode<'a>,
-    Node::BorrowedChildren: Clone,
 {
     type Item = TreeContext<Node::BorrowedValue, Node::BorrowedChildren>;
     fn advance(&mut self) {
@@ -216,6 +244,31 @@ where
     postorder_ancestors_streaming_iterator_impl!(get_value_and_children_iter);
 }
 
+crate::collection_iterators::borrowed_collection_iterator_impl!(
+    BorrowedBinaryDFSPostorderCollectionIterator,
+    BorrowedBinaryDFSPostorderIterator,
+    BorrowedBinaryTreeNode
+);
+
+impl<'a, IntoIter, Node> BorrowedBinaryDFSPostorderCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a Node>,
+    Node: BorrowedBinaryTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(
+        self,
+    ) -> BorrowedBinaryDFSPostorderCollectionIteratorWithContext<'a, IntoIter, Node> {
+        BorrowedBinaryDFSPostorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::borrowed_binary_collection_context_iterator_impl!(
+    BorrowedBinaryDFSPostorderCollectionIteratorWithContext,
+    BorrowedBinaryDFSPostorderIteratorWithContext,
+    BorrowedBinaryDFSPostorderCollectionIterator
+);
+
 pub struct BorrowedBinaryDFSPostorderIterator<'a, Node>
 where
     Node: BorrowedBinaryTreeNode<'a>,
@@ -252,7 +305,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS postorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                BorrowedBinaryDFSPostorderIteratorWithContext::new(root)
+                BorrowedBinaryDFSPostorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -333,10 +386,17 @@ impl<'a, Node> BorrowedBinaryDFSPostorderIteratorWithContext<'a, Node>
 where
     Node: BorrowedBinaryTreeNode<'a>,
 {
-    fn new(root: &'a Node) -> BorrowedBinaryDFSPostorderIteratorWithContext<'_, Node> {
+    fn new(
+        root: &'a Node,
+        path: Vec<usize>,
+    ) -> BorrowedBinaryDFSPostorderIteratorWithContext<'_, Node> {
         Self {
             root: Some(root),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
             traversal_stack: Vec::new(),
             into_iterator_stack: Vec::new(),
         }

--- a/src/dfs_postorder_iterators/owned.rs
+++ b/src/dfs_postorder_iterators/owned.rs
@@ -18,6 +18,29 @@ use super::{
     postorder_ancestors_streaming_iterator_impl,
 };
 
+crate::collection_iterators::owned_collection_iterator_impl!(
+    OwnedDFSPostorderCollectionIterator,
+    OwnedDFSPostorderIterator,
+    OwnedTreeNode
+);
+
+impl<IntoIter> OwnedDFSPostorderCollectionIterator<IntoIter>
+where
+    IntoIter: IntoIterator,
+    IntoIter::Item: OwnedTreeNode,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(self) -> OwnedDFSPostorderCollectionIteratorWithContext<IntoIter> {
+        OwnedDFSPostorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::owned_collection_context_no_children_iterator_impl!(
+    OwnedDFSPostorderCollectionIteratorWithContext,
+    OwnedDFSPostorderIteratorWithContext,
+    OwnedDFSPostorderCollectionIterator
+);
+
 pub struct OwnedDFSPostorderIterator<Node>
 where
     Node: OwnedTreeNode,
@@ -54,7 +77,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS postorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                OwnedDFSPostorderIteratorWithContext::new(root)
+                OwnedDFSPostorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -91,11 +114,15 @@ impl<'a, Node> OwnedDFSPostorderIteratorWithContext<Node>
 where
     Node: OwnedTreeNode,
 {
-    fn new(root: Node) -> OwnedDFSPostorderIteratorWithContext<Node> {
+    fn new(root: Node, path: Vec<usize>) -> OwnedDFSPostorderIteratorWithContext<Node> {
         Self {
             root: Some(root),
             traversal_stack: Vec::new(),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
         }
     }
 }
@@ -211,6 +238,29 @@ where
     get_mut_ancestors!();
 }
 
+crate::collection_iterators::owned_collection_iterator_impl!(
+    OwnedBinaryDFSPostorderCollectionIterator,
+    OwnedBinaryDFSPostorderIterator,
+    OwnedBinaryTreeNode
+);
+
+impl<IntoIter> OwnedBinaryDFSPostorderCollectionIterator<IntoIter>
+where
+    IntoIter: IntoIterator,
+    IntoIter::Item: OwnedBinaryTreeNode,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(self) -> OwnedBinaryDFSPostorderCollectionIteratorWithContext<IntoIter> {
+        OwnedBinaryDFSPostorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::owned_collection_binary_context_no_children_iterator_impl!(
+    OwnedBinaryDFSPostorderCollectionIteratorWithContext,
+    OwnedBinaryDFSPostorderIteratorWithContext,
+    OwnedBinaryDFSPostorderCollectionIterator
+);
+
 pub struct OwnedBinaryDFSPostorderIterator<Node>
 where
     Node: OwnedBinaryTreeNode,
@@ -247,7 +297,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS postorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                OwnedBinaryDFSPostorderIteratorWithContext::new(root)
+                OwnedBinaryDFSPostorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -333,10 +383,14 @@ impl<'a, Node> OwnedBinaryDFSPostorderIteratorWithContext<Node>
 where
     Node: OwnedBinaryTreeNode,
 {
-    fn new(root: Node) -> OwnedBinaryDFSPostorderIteratorWithContext<Node> {
+    fn new(root: Node, path: Vec<usize>) -> OwnedBinaryDFSPostorderIteratorWithContext<Node> {
         Self {
             root: Some(root),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
             traversal_stack: Vec::new(),
         }
     }
@@ -394,6 +448,19 @@ where
             None
         } else {
             Some(&self.current_context)
+        }
+    }
+}
+
+impl<'a, Node> StreamingIteratorMut for OwnedBinaryDFSPostorderIteratorWithContext<Node>
+where
+    Node: OwnedBinaryTreeNode,
+{
+    fn get_mut(&mut self) -> Option<&mut Self::Item> {
+        if self.current_context.ancestors.is_empty() {
+            None
+        } else {
+            Some(&mut self.current_context)
         }
     }
 }

--- a/src/dfs_preorder_iterators/borrow.rs
+++ b/src/dfs_preorder_iterators/borrow.rs
@@ -22,6 +22,50 @@ use super::{
     preorder_binary_context_streaming_iterator_impl, preorder_context_streaming_iterator_impl,
 };
 
+crate::collection_iterators::borrowed_collection_iterator_impl!(
+    BorrowedDFSPreorderCollectionIterator,
+    BorrowedDFSPreorderIterator,
+    BorrowedTreeNode
+);
+
+impl<'a, IntoIter, Node> BorrowedDFSPreorderCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a Node>,
+    Node: BorrowedTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(
+        self,
+    ) -> BorrowedDFSPreorderCollectionIteratorWithContext<'a, IntoIter, Node> {
+        BorrowedDFSPreorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::borrowed_collection_context_iterator_impl!(
+    BorrowedDFSPreorderCollectionIteratorWithContext,
+    BorrowedDFSPreorderIteratorWithContext,
+    BorrowedDFSPreorderCollectionIterator
+);
+
+impl<'a, IntoIter, Node> BorrowedBinaryDFSPreorderCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a Node>,
+    Node: BorrowedBinaryTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(
+        self,
+    ) -> BorrowedBinaryDFSPreorderCollectionIteratorWithContext<'a, IntoIter, Node> {
+        BorrowedBinaryDFSPreorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::borrowed_binary_collection_context_iterator_impl!(
+    BorrowedBinaryDFSPreorderCollectionIteratorWithContext,
+    BorrowedBinaryDFSPreorderIteratorWithContext,
+    BorrowedBinaryDFSPreorderCollectionIterator
+);
+
 pub struct BorrowedDFSPreorderIterator<'a, Node>
 where
     Node: BorrowedTreeNode<'a>,
@@ -58,7 +102,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS preorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                BorrowedDFSPreorderIteratorWithContext::new(root)
+                BorrowedDFSPreorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -153,11 +197,15 @@ impl<'a, Node> BorrowedDFSPreorderIteratorWithContext<'a, Node>
 where
     Node: BorrowedTreeNode<'a>,
 {
-    pub(crate) fn new(root: &'a Node) -> Self {
+    pub(crate) fn new(root: &'a Node, path: Vec<usize>) -> Self {
         Self {
             root: Some(root),
             traversal_stack: Vec::new(),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
         }
     }
 }
@@ -217,6 +265,12 @@ where
     preorder_ancestors_streaming_iterator_impl!(get_value_and_children_iter);
 }
 
+crate::collection_iterators::borrowed_collection_iterator_impl!(
+    BorrowedBinaryDFSPreorderCollectionIterator,
+    BorrowedBinaryDFSPreorderIterator,
+    BorrowedBinaryTreeNode
+);
+
 pub struct BorrowedBinaryDFSPreorderIterator<'a, Node>
 where
     Node: BorrowedBinaryTreeNode<'a>,
@@ -251,7 +305,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS preorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                BorrowedBinaryDFSPreorderIteratorWithContext::new(root)
+                BorrowedBinaryDFSPreorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -389,11 +443,15 @@ impl<'a, Node> BorrowedBinaryDFSPreorderIteratorWithContext<'a, Node>
 where
     Node: BorrowedBinaryTreeNode<'a>,
 {
-    pub(crate) fn new(root: &'a Node) -> Self {
+    pub(crate) fn new(root: &'a Node, path: Vec<usize>) -> Self {
         Self {
             root: Some(root),
             traversal_stack: Vec::new(),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
         }
     }
 }

--- a/src/dfs_preorder_iterators/mut_borrow.rs
+++ b/src/dfs_preorder_iterators/mut_borrow.rs
@@ -24,6 +24,31 @@ use super::{
     preorder_context_streaming_iterator_impl,
 };
 
+crate::collection_iterators::mut_borrowed_collection_iterator_impl!(
+    MutBorrowedDFSPreorderCollectionIterator,
+    MutBorrowedDFSPreorderIterator,
+    MutBorrowedTreeNode
+);
+
+impl<'a, IntoIter, Node> MutBorrowedDFSPreorderCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a mut Node>,
+    Node: MutBorrowedTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(
+        self,
+    ) -> MutBorrowedDFSPreorderCollectionIteratorWithContext<'a, IntoIter, Node> {
+        MutBorrowedDFSPreorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::mut_borrowed_collection_context_iterator_impl!(
+    MutBorrowedDFSPreorderCollectionIteratorWithContext,
+    MutBorrowedDFSPreorderIteratorWithContext,
+    MutBorrowedDFSPreorderCollectionIterator
+);
+
 pub struct MutBorrowedDFSPreorderIterator<'a, Node>
 where
     Node: MutBorrowedTreeNode<'a>,
@@ -61,7 +86,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS preorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                MutBorrowedDFSPreorderIteratorWithContext::new(root)
+                MutBorrowedDFSPreorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -156,11 +181,15 @@ impl<'a, Node> MutBorrowedDFSPreorderIteratorWithContext<'a, Node>
 where
     Node: MutBorrowedTreeNode<'a>,
 {
-    pub(crate) fn new(root: &'a mut Node) -> Self {
+    pub(crate) fn new(root: &'a mut Node, path: Vec<usize>) -> Self {
         Self {
             root: Some(root),
             traversal_stack: Vec::new(),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
         }
     }
 }
@@ -233,6 +262,31 @@ where
     get_mut_ancestors!();
 }
 
+crate::collection_iterators::mut_borrowed_collection_iterator_impl!(
+    MutBorrowedBinaryDFSPreorderCollectionIterator,
+    MutBorrowedBinaryDFSPreorderIterator,
+    MutBorrowedBinaryTreeNode
+);
+
+impl<'a, IntoIter, Node> MutBorrowedBinaryDFSPreorderCollectionIterator<'a, IntoIter, Node>
+where
+    IntoIter: IntoIterator<Item = &'a mut Node>,
+    Node: MutBorrowedBinaryTreeNode<'a>,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(
+        self,
+    ) -> MutBorrowedBinaryDFSPreorderCollectionIteratorWithContext<'a, IntoIter, Node> {
+        MutBorrowedBinaryDFSPreorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::mut_borrowed_binary_collection_context_iterator_impl!(
+    MutBorrowedBinaryDFSPreorderCollectionIteratorWithContext,
+    MutBorrowedBinaryDFSPreorderIteratorWithContext,
+    MutBorrowedBinaryDFSPreorderCollectionIterator
+);
+
 pub struct MutBorrowedBinaryDFSPreorderIterator<'a, Node>
 where
     Node: MutBorrowedBinaryTreeNode<'a>,
@@ -267,7 +321,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS preorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                MutBorrowedBinaryDFSPreorderIteratorWithContext::new(root)
+                MutBorrowedBinaryDFSPreorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -417,11 +471,15 @@ impl<'a, Node> MutBorrowedBinaryDFSPreorderIteratorWithContext<'a, Node>
 where
     Node: MutBorrowedBinaryTreeNode<'a>,
 {
-    pub(crate) fn new(root: &'a mut Node) -> Self {
+    pub(crate) fn new(root: &'a mut Node, path: Vec<usize>) -> Self {
         Self {
             root: Some(root),
             traversal_stack: Vec::new(),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
         }
     }
 }

--- a/src/dfs_preorder_iterators/owned.rs
+++ b/src/dfs_preorder_iterators/owned.rs
@@ -24,6 +24,29 @@ use super::{
     preorder_context_streaming_iterator_impl,
 };
 
+crate::collection_iterators::owned_collection_iterator_impl!(
+    OwnedDFSPreorderCollectionIterator,
+    OwnedDFSPreorderIterator,
+    OwnedTreeNode
+);
+
+impl<IntoIter> OwnedDFSPreorderCollectionIterator<IntoIter>
+where
+    IntoIter: IntoIterator,
+    IntoIter::Item: OwnedTreeNode,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(self) -> OwnedDFSPreorderCollectionIteratorWithContext<IntoIter> {
+        OwnedDFSPreorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::owned_collection_context_iterator_impl!(
+    OwnedDFSPreorderCollectionIteratorWithContext,
+    OwnedDFSPreorderIteratorWithContext,
+    OwnedDFSPreorderCollectionIterator
+);
+
 pub struct OwnedDFSPreorderIterator<Node>
 where
     Node: OwnedTreeNode,
@@ -58,7 +81,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS preorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                OwnedDFSPreorderIteratorWithContext::new(root)
+                OwnedDFSPreorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -151,11 +174,15 @@ impl<'a, Node> OwnedDFSPreorderIteratorWithContext<Node>
 where
     Node: OwnedTreeNode,
 {
-    pub(crate) fn new(root: Node) -> Self {
+    pub(crate) fn new(root: Node, path: Vec<usize>) -> Self {
         Self {
             root: Some(root),
             traversal_stack: Vec::new(),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
         }
     }
 }
@@ -227,6 +254,29 @@ where
     get_mut_ancestors!();
 }
 
+crate::collection_iterators::owned_collection_iterator_impl!(
+    OwnedBinaryDFSPreorderCollectionIterator,
+    OwnedBinaryDFSPreorderIterator,
+    OwnedBinaryTreeNode
+);
+
+impl<IntoIter> OwnedBinaryDFSPreorderCollectionIterator<IntoIter>
+where
+    IntoIter: IntoIterator,
+    IntoIter::Item: OwnedBinaryTreeNode,
+{
+    #[doc = include_str!("../../doc_files/collection_attach_context.md")]
+    pub fn attach_context(self) -> OwnedBinaryDFSPreorderCollectionIteratorWithContext<IntoIter> {
+        OwnedBinaryDFSPreorderCollectionIteratorWithContext::new(self)
+    }
+}
+
+crate::collection_iterators::owned_collection_binary_context_iterator_impl!(
+    OwnedBinaryDFSPreorderCollectionIteratorWithContext,
+    OwnedBinaryDFSPreorderIteratorWithContext,
+    OwnedBinaryDFSPreorderCollectionIterator
+);
+
 pub struct OwnedBinaryDFSPreorderIterator<Node>
 where
     Node: OwnedBinaryTreeNode,
@@ -261,7 +311,7 @@ where
         match self.root {
             None => panic!("Attempted to attach metadata to a DFS preorder iterator in the middle of a tree traversal. This is forbidden."),
             Some(root) => {
-                OwnedBinaryDFSPreorderIteratorWithContext::new(root)
+                OwnedBinaryDFSPreorderIteratorWithContext::new(root, Vec::new())
             }
         }
     }
@@ -405,11 +455,15 @@ impl<Node> OwnedBinaryDFSPreorderIteratorWithContext<Node>
 where
     Node: OwnedBinaryTreeNode,
 {
-    pub(crate) fn new(root: Node) -> Self {
+    pub(crate) fn new(root: Node, path: Vec<usize>) -> Self {
         Self {
             root: Some(root),
             traversal_stack: Vec::new(),
-            current_context: TreeContext::new(),
+            current_context: TreeContext {
+                path,
+                ancestors: Vec::new(),
+                children: None,
+            },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 extern crate core;
 
 pub mod bfs_iterators;
+pub(crate) mod collection_iterators;
 pub mod dfs_inorder_iterators;
 pub mod dfs_postorder_iterators;
 pub mod dfs_preorder_iterators;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3260,6 +3260,8 @@ where
 
 impl<T> OwnedIntoIteratorOfTrees<T> for Vec<T> where T: OwnedTreeNode {}
 impl<T> OwnedIntoIteratorOfBinaryTrees<T> for Vec<T> where T: OwnedBinaryTreeNode {}
+impl<const LEN: usize, T> OwnedIntoIteratorOfTrees<T> for [T; LEN] where T: OwnedTreeNode {}
+impl<const LEN: usize, T> OwnedIntoIteratorOfBinaryTrees<T> for [T; LEN] where T: OwnedBinaryTreeNode {}
 
 impl<'a, T> MutBorrowedIntoIteratorOfTrees<'a, T> for &'a mut Vec<T> where T: MutBorrowedTreeNode<'a>
 {}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3265,9 +3265,15 @@ impl<const LEN: usize, T> OwnedIntoIteratorOfBinaryTrees<T> for [T; LEN] where T
 
 impl<'a, T> MutBorrowedIntoIteratorOfTrees<'a, T> for &'a mut Vec<T> where T: MutBorrowedTreeNode<'a>
 {}
+impl<'a, const LEN: usize, T> MutBorrowedIntoIteratorOfTrees<'a, T> for &'a mut [T; LEN] where T: MutBorrowedTreeNode<'a>
+{}
 impl<'a, T> MutBorrowedIntoIteratorOfTrees<'a, T> for IterMut<'a, T> where T: MutBorrowedTreeNode<'a>
 {}
 impl<'a, T> MutBorrowedIntoIteratorOfBinaryTrees<'a, T> for &'a mut Vec<T> where
+    T: MutBorrowedBinaryTreeNode<'a>
+{
+}
+impl<'a, const LEN: usize, T> MutBorrowedIntoIteratorOfBinaryTrees<'a, T> for &'a mut [T; LEN] where
     T: MutBorrowedBinaryTreeNode<'a>
 {
 }
@@ -3277,8 +3283,13 @@ impl<'a, T> MutBorrowedIntoIteratorOfBinaryTrees<'a, T> for IterMut<'a, T> where
 }
 
 impl<'a, T> BorrowedIntoIteratorOfTrees<'a, T> for &'a Vec<T> where T: BorrowedTreeNode<'a> {}
+impl<'a, T> BorrowedIntoIteratorOfTrees<'a, T> for &'a [T] where T: BorrowedTreeNode<'a> {}
 impl<'a, T> BorrowedIntoIteratorOfTrees<'a, T> for Iter<'a, T> where T: BorrowedTreeNode<'a> {}
 impl<'a, T> BorrowedIntoIteratorOfBinaryTrees<'a, T> for &'a Vec<T> where
+    T: BorrowedBinaryTreeNode<'a>
+{
+}
+impl<'a, const LEN: usize, T> BorrowedIntoIteratorOfBinaryTrees<'a, T> for &'a [T; LEN] where
     T: BorrowedBinaryTreeNode<'a>
 {
 }

--- a/src/tree_context.rs
+++ b/src/tree_context.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TreeContext<Value, Children> {
     #[doc = include_str!("../doc_files/path.md")]
     pub(crate) path: Vec<usize>,

--- a/src/tree_context.rs
+++ b/src/tree_context.rs
@@ -13,14 +13,6 @@ pub struct TreeContext<Value, Children> {
 }
 
 impl<Value, Children> TreeContext<Value, Children> {
-    pub(crate) fn new() -> Self {
-        Self {
-            path: Vec::new(),
-            ancestors: Vec::new(),
-            children: None,
-        }
-    }
-
     /// Gets the depth of the current node in the tree. This is zero-based,
     /// so the root node is at depth zero.
     ///


### PR DESCRIPTION
This pull request adds some APIs for working with collections of trees. These new APIs track the path - including the index into the collection of trees itself. These also allow for `for` loop flattening when working with these collections of trees.